### PR TITLE
fix: off-by-one suppression count and recursive summary throttling

### DIFF
--- a/src/application/emitter.rs
+++ b/src/application/emitter.rs
@@ -482,9 +482,9 @@ mod tests {
 
         // Verify counts
         let counts: Vec<usize> = summaries.iter().map(|s| s.count).collect();
-        assert!(counts.contains(&6)); // 5 + 1 (initial)
-        assert!(counts.contains(&11)); // 10 + 1
-        assert!(counts.contains(&16)); // 15 + 1
+        assert!(counts.contains(&5));
+        assert!(counts.contains(&10));
+        assert!(counts.contains(&15));
     }
 
     #[test]
@@ -516,7 +516,7 @@ mod tests {
 
         // Only the high-count event should be included
         assert_eq!(summaries.len(), 1);
-        assert_eq!(summaries[0].count, 15); // 14 + 1 initial
+        assert_eq!(summaries[0].count, 14);
     }
 
     #[cfg(feature = "async")]

--- a/src/application/limiter.rs
+++ b/src/application/limiter.rs
@@ -306,9 +306,9 @@ mod tests {
         assert_eq!(limiter.check_event(sig), LimitDecision::Suppress);
         assert_eq!(limiter.check_event(sig), LimitDecision::Suppress);
 
-        // Check counter - initial creation counts as 1, plus 3 recorded = 4 total
+        // Check counter - 3 suppressions recorded
         registry.with_event_state(sig, |state, _now| {
-            assert_eq!(state.counter.count(), 4);
+            assert_eq!(state.counter.count(), 3);
         });
     }
 
@@ -608,7 +608,7 @@ mod tests {
 
         // Verify state exists
         let initial_count = registry.with_event_state(sig, |state, _| state.counter.count());
-        assert_eq!(initial_count, 1);
+        assert_eq!(initial_count, 0);
 
         // Open circuit breaker
         for _ in 0..10 {

--- a/src/application/registry.rs
+++ b/src/application/registry.rs
@@ -200,7 +200,7 @@ mod tests {
 
         // First access creates state
         registry.with_event_state(sig, |state, _now| {
-            assert_eq!(state.counter.count(), 1);
+            assert_eq!(state.counter.count(), 0);
         });
 
         assert_eq!(registry.len(), 1);

--- a/src/domain/summary.rs
+++ b/src/domain/summary.rs
@@ -35,11 +35,11 @@ impl Clone for SuppressionCounter {
 }
 
 impl SuppressionCounter {
-    /// Create a new counter with initial suppression.
+    /// Create a new counter (initially zero suppressions).
     pub fn new(initial_timestamp: Instant) -> Self {
         let nanos = Self::instant_to_nanos(initial_timestamp);
         Self {
-            suppressed_count: AtomicUsize::new(1),
+            suppressed_count: AtomicUsize::new(0),
             first_suppressed_nanos: AtomicU64::new(nanos),
             last_suppressed_nanos: AtomicU64::new(nanos),
         }
@@ -269,13 +269,13 @@ mod tests {
         let now = Instant::now();
         let counter = SuppressionCounter::new(now);
 
+        assert_eq!(counter.count(), 0);
+
+        counter.record_suppression(now);
         assert_eq!(counter.count(), 1);
 
         counter.record_suppression(now);
         assert_eq!(counter.count(), 2);
-
-        counter.record_suppression(now);
-        assert_eq!(counter.count(), 3);
     }
 
     #[test]
@@ -304,7 +304,7 @@ mod tests {
 
         counter.record_suppression(now);
         counter.record_suppression(now);
-        assert_eq!(counter.count(), 3);
+        assert_eq!(counter.count(), 2);
 
         counter.reset(now);
         assert_eq!(counter.count(), 0);
@@ -322,7 +322,7 @@ mod tests {
         let summary = SuppressionSummary::from_counter(sig, &counter);
 
         assert_eq!(summary.signature, sig);
-        assert_eq!(summary.count, 2);
+        assert_eq!(summary.count, 1);
         assert!(summary.duration >= Duration::from_millis(10));
     }
 
@@ -336,7 +336,7 @@ mod tests {
         let summary = SuppressionSummary::from_counter(sig, &counter);
         let message = summary.format_message();
 
-        assert!(message.contains("suppressed 2 times"));
+        assert!(message.contains("suppressed 1 times"));
         assert!(message.contains(&sig.to_string()));
     }
 
@@ -351,7 +351,7 @@ mod tests {
             counter.record_suppression(now);
         }
 
-        assert_eq!(counter.count(), 10_001); // 10,000 + 1 initial
+        assert_eq!(counter.count(), 10_000);
     }
 
     #[test]
@@ -378,8 +378,8 @@ mod tests {
             handle.join().unwrap();
         }
 
-        // 10 threads * 100 updates + 1 initial = 1001
-        assert_eq!(counter.count(), 1001);
+        // 10 threads * 100 updates = 1000
+        assert_eq!(counter.count(), 1000);
     }
 
     #[test]
@@ -391,7 +391,7 @@ mod tests {
         // Immediately create summary (same timestamp)
         let summary = SuppressionSummary::from_counter(sig, &counter);
 
-        assert_eq!(summary.count, 1);
+        assert_eq!(summary.count, 0);
         assert!(summary.duration < Duration::from_millis(1));
     }
 
@@ -401,7 +401,7 @@ mod tests {
         let counter = SuppressionCounter::new(now);
 
         counter.record_suppression(now);
-        assert_eq!(counter.count(), 2);
+        assert_eq!(counter.count(), 1);
 
         counter.reset(now);
         assert_eq!(counter.count(), 0);
@@ -440,8 +440,8 @@ mod tests {
         counter1.record_suppression(now);
 
         // counter2 should not be affected
-        assert_eq!(counter1.count(), 2);
-        assert_eq!(counter2.count(), 1);
+        assert_eq!(counter1.count(), 1);
+        assert_eq!(counter2.count(), 0);
     }
 
     #[test]
@@ -535,7 +535,7 @@ mod tests {
             counter.record_suppression(now);
         }
 
-        assert_eq!(counter.count(), 100_001);
+        assert_eq!(counter.count(), 100_000);
     }
 
     #[test]
@@ -579,7 +579,7 @@ mod tests {
         // Should not panic, timestamps should saturate gracefully
         let _first = counter.first_suppressed();
         let _last = counter.last_suppressed();
-        assert!(counter.count() > 1);
+        assert!(counter.count() > 0);
     }
 
     #[test]
@@ -631,7 +631,7 @@ mod tests {
         let counter_clone2 = Arc::clone(&counter);
         let done_clone2 = Arc::clone(&done);
         let reader = thread::spawn(move || {
-            let mut last_count = 1;
+            let mut last_count = 0;
             while !done_clone2.load(Ordering::Acquire) {
                 let count = counter_clone2.count();
                 // Count should never decrease
@@ -644,8 +644,8 @@ mod tests {
         writer.join().unwrap();
         reader.join().unwrap();
 
-        // Final count should be 101 (1 initial + 100 recorded)
-        assert_eq!(counter.count(), 101);
+        // Final count should be 100
+        assert_eq!(counter.count(), 100);
     }
 
     #[test]
@@ -657,7 +657,7 @@ mod tests {
         // Create summary immediately - same timestamp for first and last
         let summary = SuppressionSummary::from_counter(sig, &counter);
 
-        assert_eq!(summary.count, 1);
+        assert_eq!(summary.count, 0);
         assert_eq!(summary.duration, Duration::from_secs(0));
         assert_eq!(summary.first_suppressed, summary.last_suppressed);
     }

--- a/src/infrastructure/layer.rs
+++ b/src/infrastructure/layer.rs
@@ -17,6 +17,8 @@ use crate::infrastructure::storage::ShardedStorage;
 use crate::infrastructure::visitor::FieldVisitor;
 
 use std::borrow::Cow;
+#[cfg(feature = "async")]
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +26,33 @@ use tracing::{Metadata, Subscriber};
 use tracing_subscriber::layer::Filter;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{layer::Context, Layer};
+
+#[cfg(feature = "async")]
+thread_local! {
+    /// Guard against re-entrant event processing (e.g., summary emissions triggering throttling).
+    /// Only relevant when active emission is enabled, since summary formatters emit tracing
+    /// events that would otherwise be recursively throttled on the same thread.
+    static IN_THROTTLE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// RAII guard that resets IN_THROTTLE to false on drop, even during panics.
+#[cfg(feature = "async")]
+struct ThrottleGuard;
+
+#[cfg(feature = "async")]
+impl ThrottleGuard {
+    fn enter() -> Self {
+        IN_THROTTLE.with(|flag| flag.set(true));
+        ThrottleGuard
+    }
+}
+
+#[cfg(feature = "async")]
+impl Drop for ThrottleGuard {
+    fn drop(&mut self) {
+        IN_THROTTLE.with(|flag| flag.set(false));
+    }
+}
 
 #[cfg(feature = "async")]
 use crate::application::emitter::{EmitterHandle, SummaryEmitter};
@@ -554,6 +583,7 @@ impl TracingRateLimitLayerBuilder {
 
             let handle = emitter.start(
                 move |summaries| {
+                    let _guard = ThrottleGuard::enter();
                     for summary in summaries {
                         formatter(&summary);
                     }
@@ -906,11 +936,18 @@ where
     }
 
     fn event_enabled(&self, event: &tracing::Event<'_>, cx: &Context<'_, Sub>) -> bool {
+        // Prevent re-entrant throttling (e.g., summary emissions triggering throttling)
+        #[cfg(feature = "async")]
+        if IN_THROTTLE.with(|flag| flag.get()) {
+            return true;
+        }
+
         let metadata_obj = event.metadata();
 
         // Check if this target is exempt from rate limiting
         // Skip the lookup if no exempt targets are configured (common case)
-        if !self.exempt_targets.is_empty() && self.exempt_targets.contains(metadata_obj.target()) {
+        let target = metadata_obj.target();
+        if !self.exempt_targets.is_empty() && self.exempt_targets.contains(target) {
             // Exempt targets bypass rate limiting entirely
             self.limiter.metrics().record_allowed();
             return true;
@@ -1585,5 +1622,48 @@ mod tests {
         assert!(count > 0, "Default formatter should have emitted summaries");
 
         handle.shutdown().await.expect("shutdown failed");
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_summary_emission_not_recursively_throttled() {
+        use std::time::Duration;
+
+        // Build a layer with active emission and a very restrictive policy
+        let layer = TracingRateLimitLayer::builder()
+            .with_policy(Policy::count_based(1).unwrap())
+            .with_active_emission(true)
+            .with_summary_interval(Duration::from_millis(100))
+            .build()
+            .unwrap();
+
+        let layer_clone = layer.clone();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(layer));
+
+        // Emit events to trigger suppressions, then wait for multiple summary intervals.
+        // If summaries were recursively throttled, the second interval would produce
+        // nested "Suppressed 1 times: ... Suppressed N times: ..." messages and the
+        // signature count would keep growing.
+        tracing::subscriber::with_default(subscriber, || {
+            // Trigger suppressions
+            for _ in 0..5 {
+                tracing::info!(target: "myapp", "repetitive event");
+            }
+        });
+
+        // Wait for two summary intervals
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        // Signature count should be exactly 1 (the "myapp" event).
+        // If summary events were being throttled, additional signatures would appear.
+        assert_eq!(
+            layer_clone.signature_count(),
+            1,
+            "Summary emissions should not create additional throttle signatures"
+        );
+
+        layer_clone.shutdown().await.expect("shutdown failed");
     }
 }

--- a/src/infrastructure/layer.rs
+++ b/src/infrastructure/layer.rs
@@ -17,8 +17,6 @@ use crate::infrastructure::storage::ShardedStorage;
 use crate::infrastructure::visitor::FieldVisitor;
 
 use std::borrow::Cow;
-#[cfg(feature = "async")]
-use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -27,32 +25,13 @@ use tracing_subscriber::layer::Filter;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{layer::Context, Layer};
 
+/// Internal target used for summary emission events.
+///
+/// Events emitted with this target are automatically exempt from throttling to
+/// prevent recursive suppression of summary messages. This target is intentionally
+/// internal and not part of the public API.
 #[cfg(feature = "async")]
-thread_local! {
-    /// Guard against re-entrant event processing (e.g., summary emissions triggering throttling).
-    /// Only relevant when active emission is enabled, since summary formatters emit tracing
-    /// events that would otherwise be recursively throttled on the same thread.
-    static IN_THROTTLE: Cell<bool> = const { Cell::new(false) };
-}
-
-/// RAII guard that resets IN_THROTTLE to false on drop, even during panics.
-#[cfg(feature = "async")]
-struct ThrottleGuard;
-
-#[cfg(feature = "async")]
-impl ThrottleGuard {
-    fn enter() -> Self {
-        IN_THROTTLE.with(|flag| flag.set(true));
-        ThrottleGuard
-    }
-}
-
-#[cfg(feature = "async")]
-impl Drop for ThrottleGuard {
-    fn drop(&mut self) {
-        IN_THROTTLE.with(|flag| flag.set(false));
-    }
-}
+const SUMMARY_TARGET: &str = "tracing_throttle::summary";
 
 #[cfg(feature = "async")]
 use crate::application::emitter::{EmitterHandle, SummaryEmitter};
@@ -573,6 +552,7 @@ impl TracingRateLimitLayerBuilder {
             let formatter = self.summary_formatter.unwrap_or_else(|| {
                 Arc::new(|summary: &SuppressionSummary| {
                     tracing::warn!(
+                        target: SUMMARY_TARGET,
                         signature = %summary.signature,
                         count = summary.count,
                         "{}",
@@ -583,7 +563,6 @@ impl TracingRateLimitLayerBuilder {
 
             let handle = emitter.start(
                 move |summaries| {
-                    let _guard = ThrottleGuard::enter();
                     for summary in summaries {
                         formatter(&summary);
                     }
@@ -936,17 +915,19 @@ where
     }
 
     fn event_enabled(&self, event: &tracing::Event<'_>, cx: &Context<'_, Sub>) -> bool {
-        // Prevent re-entrant throttling (e.g., summary emissions triggering throttling)
+        let metadata_obj = event.metadata();
+        let target = metadata_obj.target();
+
+        // Exempt our internal summary emission target to prevent recursive throttling.
+        // Only the default formatter uses this target; custom formatters are the user's
+        // responsibility and are intentionally subject to normal throttling rules.
         #[cfg(feature = "async")]
-        if IN_THROTTLE.with(|flag| flag.get()) {
+        if target == SUMMARY_TARGET {
             return true;
         }
 
-        let metadata_obj = event.metadata();
-
         // Check if this target is exempt from rate limiting
         // Skip the lookup if no exempt targets are configured (common case)
-        let target = metadata_obj.target();
         if !self.exempt_targets.is_empty() && self.exempt_targets.contains(target) {
             // Exempt targets bypass rate limiting entirely
             self.limiter.metrics().record_allowed();
@@ -975,7 +956,7 @@ where
             let event_metadata = crate::domain::metadata::EventMetadata::new(
                 metadata_obj.level().as_str().to_string(),
                 message,
-                metadata_obj.target().to_string(),
+                target.to_string(),
                 combined_fields,
             );
 

--- a/tests/redis_storage.rs
+++ b/tests/redis_storage.rs
@@ -61,7 +61,7 @@ async fn test_redis_basic_set_get() {
         sig,
         || EventState::new(policy.clone(), Instant::now()),
         |state| {
-            assert_eq!(state.counter.count(), 1);
+            assert_eq!(state.counter.count(), 0);
         },
     );
 
@@ -70,7 +70,7 @@ async fn test_redis_basic_set_get() {
         sig,
         || panic!("Should not create new state"),
         |state| {
-            assert_eq!(state.counter.count(), 1);
+            assert_eq!(state.counter.count(), 0);
             state.counter.record_suppression(Instant::now());
         },
     );
@@ -80,7 +80,7 @@ async fn test_redis_basic_set_get() {
         sig,
         || panic!("Should not create new state"),
         |state| {
-            assert_eq!(state.counter.count(), 2);
+            assert_eq!(state.counter.count(), 1);
         },
     );
 
@@ -230,7 +230,7 @@ async fn test_redis_concurrent_access() {
     }
 
     // Final count should reflect all increments
-    // Note: Due to Redis race conditions, this might not be exactly 101 (1 initial + 100 records)
+    // Note: Due to Redis race conditions, this might not be exactly 100
     // but should be at least close
     storage.with_entry_mut(
         sig,
@@ -484,13 +484,13 @@ async fn test_redis_with_registry() {
 
     // Use registry to access state
     registry.with_event_state(sig, |state, now| {
-        assert_eq!(state.counter.count(), 1);
+        assert_eq!(state.counter.count(), 0);
         state.counter.record_suppression(now);
     });
 
     // Verify persistence
     registry.with_event_state(sig, |state, _| {
-        assert_eq!(state.counter.count(), 2);
+        assert_eq!(state.counter.count(), 1);
     });
 
     storage.clear();


### PR DESCRIPTION
## Summary

Fixes #2

- **Off-by-one fix**: `SuppressionCounter::new()` initialized `suppressed_count` to 1 instead of 0. This caused all suppression summaries to over-report by 1 (e.g., 18 instead of 17 for 20 events with 3 allowed). Now correctly starts at 0.
- **Recursive summary fix**: The default summary formatter emits `tracing::warn!()` events that were being caught by the throttle layer itself, causing infinite nesting. Fixed by emitting summaries with a dedicated internal target (`tracing_throttle::summary`) which is explicitly exempt in `event_enabled`. This is precise — only the default formatter's events bypass throttling; custom formatters remain subject to normal throttling rules.

## Test plan

- [x] All 330 existing tests pass with `--all-features`
- [x] All tests pass without `async` feature (`--no-default-features --features human-readable`)
- [x] `cargo run --example summaries` shows correct counts (7, 17, 12) and no recursive summaries
- [x] Added regression test `test_summary_emission_not_recursively_throttled` that verifies summary events do not create additional throttle signatures

Thanks to @CorMazz for the detailed report!