### PR TITLE
feat: enhance suppression summary handling and event processing

### DIFF
--- a/src/application/emitter.rs
+++ b/src/application/emitter.rs
@@ -279,7 +279,8 @@ where
     /// Collect current suppression summaries.
     ///
     /// Returns summaries for all events that have been suppressed at least
-    /// `min_count` times.
+    /// `min_count` times. This is a pure snapshot of all-time totals: it does
+    /// not mark anything as reported and does not affect periodic emission.
     pub fn collect_summaries(&self) -> Vec<SuppressionSummary> {
         let mut summaries = Vec::new();
         let min_count = self.config.min_count;
@@ -305,6 +306,40 @@ where
         summaries
     }
 
+    /// Collect summaries for suppressions that have not been reported yet,
+    /// marking them as reported.
+    ///
+    /// Unlike [`collect_summaries`](Self::collect_summaries), each summary
+    /// describes only the suppressions that occurred since the previous report
+    /// (periodic or episode-end). Signatures with no new suppressions are
+    /// skipped entirely, so repeated calls without new activity return nothing.
+    ///
+    /// The `min_count` threshold applies to the all-time suppression count of
+    /// a signature, matching `collect_summaries`.
+    pub fn collect_unreported_summaries(&self) -> Vec<SuppressionSummary> {
+        let mut summaries = Vec::new();
+        let min_count = self.config.min_count;
+
+        self.registry.for_each(|signature, state| {
+            if state.counter.count() < min_count {
+                return;
+            }
+
+            if let Some(unreported) = state.counter.claim_unreported() {
+                #[cfg(feature = "human-readable")]
+                let metadata = state.metadata.clone();
+                #[cfg(not(feature = "human-readable"))]
+                let metadata = None;
+
+                summaries.push(SuppressionSummary::from_unreported(
+                    *signature, unreported, metadata,
+                ));
+            }
+        });
+
+        summaries
+    }
+
     /// Start emitting summaries periodically (async version).
     ///
     /// This spawns a background task that emits summaries at the configured interval.
@@ -321,7 +356,8 @@ where
     /// # Cancellation Safety
     ///
     /// The spawned task is cancellation-safe:
-    /// - `collect_summaries()` reads atomically from storage without mutations
+    /// - `collect_unreported_summaries()` only advances atomic report marks;
+    ///   no other storage state is mutated
     /// - If cancelled during emission, the next startup will see correct state
     /// - Panics in `emit_fn` are caught and don't abort the task
     /// - The `emit_fn` closure should be cancellation-safe (avoid holding locks across `.await`)
@@ -381,7 +417,7 @@ where
                         if *shutdown_rx.borrow_and_update() {
                             // Emit final summaries if requested
                             if emit_final {
-                                let summaries = self.collect_summaries();
+                                let summaries = self.collect_unreported_summaries();
                                 if !summaries.is_empty() {
                                     // Panic safety for final emission too
                                     // Note: summaries will be properly dropped even if emit_fn panics
@@ -399,7 +435,7 @@ where
                         }
                     }
                     _ = ticker.tick() => {
-                        let summaries = self.collect_summaries();
+                        let summaries = self.collect_unreported_summaries();
                         if !summaries.is_empty() {
                             // Panic safety: catch panics in emit_fn to prevent task abort
                             // Note: summaries will be properly dropped even if emit_fn panics
@@ -536,7 +572,7 @@ mod tests {
             state.counter.record_suppression(now);
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         // Track emissions
         let emissions = Arc::new(Mutex::new(Vec::new()));
@@ -549,14 +585,94 @@ mod tests {
             false,
         );
 
-        // Wait for a couple of intervals
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        // Keep recording new suppressions so multiple intervals have new data
+        for _ in 0..4 {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            registry.with_event_state(sig, |state, now| {
+                state.counter.record_suppression(now);
+            });
+        }
 
         handle.shutdown().await.expect("shutdown failed");
 
-        // Should have emitted at least once
+        // Should have emitted at least twice (new suppressions each interval)
         let emission_count = emissions.lock().unwrap().len();
         assert!(emission_count >= 2);
+    }
+
+    /// Regression test for issue #4: a suppressed signature must not be
+    /// re-reported on every interval when no new suppressions occurred.
+    #[test]
+    fn test_no_reemission_without_new_suppressions() {
+        let storage = Arc::new(ShardedStorage::new());
+        let clock = Arc::new(SystemClock::new());
+        let policy = Policy::count_based(100).unwrap();
+        let registry = SuppressionRegistry::new(storage, clock, policy);
+        let emitter = SummaryEmitter::new(registry.clone(), EmitterConfig::default());
+
+        let sig = EventSignature::simple("INFO", "Initialization step");
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..9 {
+                state.counter.record_suppression(now);
+            }
+        });
+
+        // First collection reports the 9 suppressions
+        let summaries = emitter.collect_unreported_summaries();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].count, 9);
+
+        // Subsequent collections with no new suppressions report nothing
+        assert!(emitter.collect_unreported_summaries().is_empty());
+        assert!(emitter.collect_unreported_summaries().is_empty());
+    }
+
+    #[test]
+    fn test_delta_counts_per_collection() {
+        let storage = Arc::new(ShardedStorage::new());
+        let clock = Arc::new(SystemClock::new());
+        let policy = Policy::count_based(100).unwrap();
+        let registry = SuppressionRegistry::new(storage, clock, policy);
+        let emitter = SummaryEmitter::new(registry.clone(), EmitterConfig::default());
+
+        let sig = EventSignature::simple("INFO", "Chatty");
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..9 {
+                state.counter.record_suppression(now);
+            }
+        });
+        assert_eq!(emitter.collect_unreported_summaries()[0].count, 9);
+
+        // Only the new suppressions are reported, not the all-time total
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..3 {
+                state.counter.record_suppression(now);
+            }
+        });
+        assert_eq!(emitter.collect_unreported_summaries()[0].count, 3);
+    }
+
+    #[test]
+    fn test_collect_summaries_remains_cumulative_snapshot() {
+        let storage = Arc::new(ShardedStorage::new());
+        let clock = Arc::new(SystemClock::new());
+        let policy = Policy::count_based(100).unwrap();
+        let registry = SuppressionRegistry::new(storage, clock, policy);
+        let emitter = SummaryEmitter::new(registry.clone(), EmitterConfig::default());
+
+        let sig = EventSignature::simple("INFO", "Test");
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..5 {
+                state.counter.record_suppression(now);
+            }
+        });
+
+        // Pure snapshot: repeated calls keep returning the all-time total
+        assert_eq!(emitter.collect_summaries()[0].count, 5);
+        assert_eq!(emitter.collect_summaries()[0].count, 5);
+
+        // And it does not interfere with delta collection
+        assert_eq!(emitter.collect_unreported_summaries()[0].count, 5);
     }
 
     #[test]
@@ -807,7 +923,7 @@ mod tests {
             }
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = Arc::clone(&call_count);
@@ -825,8 +941,14 @@ mod tests {
             false,
         );
 
-        // Let it emit multiple times - first should panic, rest should succeed
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Let it emit multiple times - first should panic, rest should succeed.
+        // Record new suppressions so each interval has something to emit.
+        for _ in 0..5 {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            registry.with_event_state(sig, |state, now| {
+                state.counter.record_suppression(now);
+            });
+        }
 
         handle.shutdown().await.expect("shutdown failed");
 
@@ -854,7 +976,7 @@ mod tests {
             state.counter.record_suppression(now);
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = Arc::clone(&call_count);
@@ -867,8 +989,14 @@ mod tests {
             false,
         );
 
-        // Let it run and panic multiple times
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        // Let it run and panic multiple times, recording new suppressions
+        // so each interval has something to emit
+        for _ in 0..6 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            registry.with_event_state(sig, |state, now| {
+                state.counter.record_suppression(now);
+            });
+        }
 
         handle.shutdown().await.expect("shutdown failed");
 

--- a/src/application/limiter.rs
+++ b/src/application/limiter.rs
@@ -8,12 +8,11 @@ use crate::application::metrics::Metrics;
 use crate::application::ports::Storage;
 use crate::application::registry::SuppressionRegistry;
 use crate::domain::{
+    metadata::EventMetadata,
     policy::{PolicyDecision, RateLimitPolicy},
     signature::EventSignature,
+    summary::SuppressionSummary,
 };
-
-#[cfg(feature = "human-readable")]
-use crate::domain::metadata::EventMetadata;
 use std::panic;
 use std::sync::Arc;
 
@@ -77,50 +76,21 @@ where
     /// - Lock-free atomic operations where possible
     /// - No allocations in common case
     pub fn check_event(&self, signature: EventSignature) -> LimitDecision {
-        // Check circuit breaker state
-        if !self.circuit_breaker.allow_request() {
-            // Circuit is open, fail open (allow all events)
-            self.metrics.record_allowed();
-            return LimitDecision::Allow;
-        }
+        self.check_event_inner(signature, None, false).0
+    }
 
-        // Attempt rate limiting operation with panic protection
-        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            self.registry.with_event_state(signature, |state, now| {
-                // Ask the policy whether to allow this event
-                let decision = state.policy.register_event(now);
-
-                match decision {
-                    PolicyDecision::Allow => LimitDecision::Allow,
-                    PolicyDecision::Suppress => {
-                        // Record the suppression
-                        state.counter.record_suppression(now);
-                        LimitDecision::Suppress
-                    }
-                }
-            })
-        }));
-
-        let decision = match result {
-            Ok(decision) => {
-                // Operation succeeded
-                self.circuit_breaker.record_success();
-                decision
-            }
-            Err(_) => {
-                // Operation panicked, record failure and fail open
-                self.circuit_breaker.record_failure();
-                LimitDecision::Allow
-            }
-        };
-
-        // Record metrics
-        match decision {
-            LimitDecision::Allow => self.metrics.record_allowed(),
-            LimitDecision::Suppress => self.metrics.record_suppressed(),
-        }
-
-        decision
+    /// Process an event and, when the policy treats an `Allow` as the end of a
+    /// suppression episode, return a summary of the suppressions that have not
+    /// yet been reported.
+    ///
+    /// The returned summary's suppressions are marked as reported, so the
+    /// periodic emitter will not report them again. The caller is responsible
+    /// for actually emitting the summary.
+    pub fn check_event_with_summary(
+        &self,
+        signature: EventSignature,
+    ) -> (LimitDecision, Option<SuppressionSummary>) {
+        self.check_event_inner(signature, None, true)
     }
 
     /// Process an event with metadata and decide whether to allow or suppress it.
@@ -144,43 +114,91 @@ where
         signature: EventSignature,
         metadata: EventMetadata,
     ) -> LimitDecision {
+        self.check_event_inner(signature, Some(metadata), false).0
+    }
+
+    /// Like [`check_event_with_summary`](Self::check_event_with_summary), but
+    /// also captures event metadata on first occurrence.
+    ///
+    /// **Note:** Only available with the `human-readable` feature flag.
+    #[cfg(feature = "human-readable")]
+    pub fn check_event_with_metadata_and_summary(
+        &self,
+        signature: EventSignature,
+        metadata: EventMetadata,
+    ) -> (LimitDecision, Option<SuppressionSummary>) {
+        self.check_event_inner(signature, Some(metadata), true)
+    }
+
+    /// Shared implementation for all check variants.
+    ///
+    /// `close_episode` controls whether an episode-ending `Allow` claims the
+    /// unreported suppressions and returns them as a summary. Variants that
+    /// discard the summary must pass `false` so unreported suppressions stay
+    /// available to the periodic emitter.
+    fn check_event_inner(
+        &self,
+        signature: EventSignature,
+        metadata: Option<EventMetadata>,
+        close_episode: bool,
+    ) -> (LimitDecision, Option<SuppressionSummary>) {
+        #[cfg(not(feature = "human-readable"))]
+        let _ = metadata;
+
         // Check circuit breaker state
         if !self.circuit_breaker.allow_request() {
             // Circuit is open, fail open (allow all events)
             self.metrics.record_allowed();
-            return LimitDecision::Allow;
+            return (LimitDecision::Allow, None);
         }
 
         // Attempt rate limiting operation with panic protection
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             self.registry.with_event_state(signature, |state, now| {
                 // Capture metadata on first occurrence
-                state.set_metadata(metadata);
+                #[cfg(feature = "human-readable")]
+                if let Some(metadata) = metadata {
+                    state.set_metadata(metadata);
+                }
 
                 // Ask the policy whether to allow this event
                 let decision = state.policy.register_event(now);
 
                 match decision {
-                    PolicyDecision::Allow => LimitDecision::Allow,
+                    PolicyDecision::Allow => {
+                        let episode = if close_episode && state.policy.allow_ends_episode() {
+                            state.counter.claim_unreported().map(|unreported| {
+                                #[cfg(feature = "human-readable")]
+                                let metadata = state.metadata.clone();
+                                #[cfg(not(feature = "human-readable"))]
+                                let metadata = None;
+
+                                SuppressionSummary::from_unreported(signature, unreported, metadata)
+                            })
+                        } else {
+                            None
+                        };
+                        (LimitDecision::Allow, episode)
+                    }
                     PolicyDecision::Suppress => {
                         // Record the suppression
                         state.counter.record_suppression(now);
-                        LimitDecision::Suppress
+                        (LimitDecision::Suppress, None)
                     }
                 }
             })
         }));
 
-        let decision = match result {
-            Ok(decision) => {
+        let (decision, episode) = match result {
+            Ok(outcome) => {
                 // Operation succeeded
                 self.circuit_breaker.record_success();
-                decision
+                outcome
             }
             Err(_) => {
                 // Operation panicked, record failure and fail open
                 self.circuit_breaker.record_failure();
-                LimitDecision::Allow
+                (LimitDecision::Allow, None)
             }
         };
 
@@ -190,7 +208,7 @@ where
             LimitDecision::Suppress => self.metrics.record_suppressed(),
         }
 
-        decision
+        (decision, episode)
     }
 
     /// Get a reference to the registry.
@@ -364,6 +382,115 @@ mod tests {
 
         // Should have suppressed the rest
         assert!(total_suppressed >= 150);
+    }
+
+    #[test]
+    fn test_time_window_allow_closes_episode() {
+        use std::time::Duration;
+
+        let storage = Arc::new(ShardedStorage::new());
+        let mock_clock = Arc::new(MockClock::new(Instant::now()));
+        let policy = Policy::time_window(1, Duration::from_secs(60)).unwrap();
+        let registry = SuppressionRegistry::new(storage, mock_clock.clone(), policy);
+        let limiter = RateLimiter::new(registry, Metrics::new(), Arc::new(CircuitBreaker::new()));
+
+        let sig = EventSignature::simple("INFO", "Test");
+
+        // 1 allowed, 9 suppressed
+        assert_eq!(
+            limiter.check_event_with_summary(sig).0,
+            LimitDecision::Allow
+        );
+        for _ in 0..9 {
+            assert_eq!(
+                limiter.check_event_with_summary(sig).0,
+                LimitDecision::Suppress
+            );
+        }
+
+        // Window rolls over: the next Allow closes the episode
+        mock_clock.advance(Duration::from_secs(61));
+        let (decision, episode) = limiter.check_event_with_summary(sig);
+        assert_eq!(decision, LimitDecision::Allow);
+        let summary = episode.expect("episode summary expected");
+        assert_eq!(summary.count, 9);
+
+        // A new window without suppressions yields no episode summary
+        mock_clock.advance(Duration::from_secs(61));
+        let (decision, episode) = limiter.check_event_with_summary(sig);
+        assert_eq!(decision, LimitDecision::Allow);
+        assert!(episode.is_none());
+    }
+
+    #[test]
+    fn test_token_bucket_allow_does_not_close_episode() {
+        use std::time::Duration;
+
+        let storage = Arc::new(ShardedStorage::new());
+        let mock_clock = Arc::new(MockClock::new(Instant::now()));
+        let policy = Policy::token_bucket(1.0, 1.0).unwrap();
+        let registry = SuppressionRegistry::new(storage, mock_clock.clone(), policy);
+        let limiter = RateLimiter::new(
+            registry.clone(),
+            Metrics::new(),
+            Arc::new(CircuitBreaker::new()),
+        );
+
+        let sig = EventSignature::simple("INFO", "Test");
+
+        assert_eq!(
+            limiter.check_event_with_summary(sig).0,
+            LimitDecision::Allow
+        );
+        for _ in 0..5 {
+            assert_eq!(
+                limiter.check_event_with_summary(sig).0,
+                LimitDecision::Suppress
+            );
+        }
+
+        // Refill a token: allows and suppressions interleave under sustained
+        // load, so an Allow must not claim the suppressions
+        mock_clock.advance(Duration::from_secs(1));
+        let (decision, episode) = limiter.check_event_with_summary(sig);
+        assert_eq!(decision, LimitDecision::Allow);
+        assert!(episode.is_none());
+
+        // The suppressions stay available for the periodic emitter
+        registry.with_event_state(sig, |state, _| {
+            assert_eq!(state.counter.count(), 5);
+            assert_eq!(state.counter.reported(), 0);
+        });
+    }
+
+    #[test]
+    fn test_check_event_does_not_claim_episode() {
+        use std::time::Duration;
+
+        let storage = Arc::new(ShardedStorage::new());
+        let mock_clock = Arc::new(MockClock::new(Instant::now()));
+        let policy = Policy::time_window(1, Duration::from_secs(60)).unwrap();
+        let registry = SuppressionRegistry::new(storage, mock_clock.clone(), policy);
+        let limiter = RateLimiter::new(
+            registry.clone(),
+            Metrics::new(),
+            Arc::new(CircuitBreaker::new()),
+        );
+
+        let sig = EventSignature::simple("INFO", "Test");
+
+        assert_eq!(limiter.check_event(sig), LimitDecision::Allow);
+        for _ in 0..3 {
+            limiter.check_event(sig);
+        }
+
+        // check_event discards no suppressions: they remain unreported
+        mock_clock.advance(Duration::from_secs(61));
+        assert_eq!(limiter.check_event(sig), LimitDecision::Allow);
+        registry.with_event_state(sig, |state, _| {
+            assert_eq!(state.counter.reported(), 0);
+            assert_eq!(state.counter.count(), 3);
+        });
     }
 
     #[test]

--- a/src/domain/policy.rs
+++ b/src/domain/policy.rs
@@ -68,6 +68,19 @@ pub trait RateLimitPolicy: Send + Sync {
     ///
     /// Called when starting a new tracking period or when clearing history.
     fn reset(&mut self);
+
+    /// Whether an `Allow` decision marks the end of a suppression episode.
+    ///
+    /// For policies like time windows or exponential backoff, suppression
+    /// happens in episodes: once an event is allowed again, the preceding
+    /// run of suppressions is over and can be summarized as one unit.
+    ///
+    /// For policies where allows and suppressions naturally interleave under
+    /// sustained load (e.g. token bucket), an `Allow` carries no such meaning,
+    /// so this returns `false` (the default).
+    fn allow_ends_episode(&self) -> bool {
+        false
+    }
 }
 
 /// Count-based rate limiting policy.
@@ -367,6 +380,10 @@ impl RateLimitPolicy for TimeWindowPolicy {
         }
     }
 
+    fn allow_ends_episode(&self) -> bool {
+        true
+    }
+
     fn reset(&mut self) {
         self.event_timestamps.clear();
     }
@@ -428,6 +445,10 @@ impl RateLimitPolicy for ExponentialBackoffPolicy {
     fn reset(&mut self) {
         self.event_count = 0;
         self.next_allowed = 1;
+    }
+
+    fn allow_ends_episode(&self) -> bool {
+        true
     }
 }
 
@@ -758,6 +779,15 @@ impl RateLimitPolicy for Policy {
             Policy::TimeWindow(p) => p.reset(),
             Policy::ExponentialBackoff(p) => p.reset(),
             Policy::TokenBucket(p) => p.reset(),
+        }
+    }
+
+    fn allow_ends_episode(&self) -> bool {
+        match self {
+            Policy::CountBased(p) => p.allow_ends_episode(),
+            Policy::TimeWindow(p) => p.allow_ends_episode(),
+            Policy::ExponentialBackoff(p) => p.allow_ends_episode(),
+            Policy::TokenBucket(p) => p.allow_ends_episode(),
         }
     }
 }

--- a/src/domain/summary.rs
+++ b/src/domain/summary.rs
@@ -18,6 +18,10 @@ pub struct SuppressionCounter {
     first_suppressed_nanos: AtomicU64,
     /// Timestamp of last suppression (nanoseconds since epoch)
     last_suppressed_nanos: AtomicU64,
+    /// Number of suppressions already included in an emitted summary
+    reported_count: AtomicUsize,
+    /// Timestamp marking the end of the last reported range (nanoseconds since epoch)
+    reported_boundary_nanos: AtomicU64,
 }
 
 impl Clone for SuppressionCounter {
@@ -30,8 +34,23 @@ impl Clone for SuppressionCounter {
             last_suppressed_nanos: AtomicU64::new(
                 self.last_suppressed_nanos.load(Ordering::Relaxed),
             ),
+            reported_count: AtomicUsize::new(self.reported_count.load(Ordering::Relaxed)),
+            reported_boundary_nanos: AtomicU64::new(
+                self.reported_boundary_nanos.load(Ordering::Relaxed),
+            ),
         }
     }
+}
+
+/// A claimed range of suppressions that had not yet been reported in a summary.
+#[derive(Debug, Clone, Copy)]
+pub struct UnreportedSuppressions {
+    /// Number of suppressions in this range
+    pub count: usize,
+    /// Start of the range (end of the previously reported range)
+    pub since: Instant,
+    /// End of the range (most recent suppression)
+    pub until: Instant,
 }
 
 impl SuppressionCounter {
@@ -42,6 +61,8 @@ impl SuppressionCounter {
             suppressed_count: AtomicUsize::new(0),
             first_suppressed_nanos: AtomicU64::new(nanos),
             last_suppressed_nanos: AtomicU64::new(nanos),
+            reported_count: AtomicUsize::new(0),
+            reported_boundary_nanos: AtomicU64::new(nanos),
         }
     }
 
@@ -60,6 +81,8 @@ impl SuppressionCounter {
             suppressed_count: AtomicUsize::new(suppressed_count),
             first_suppressed_nanos: AtomicU64::new(first_nanos),
             last_suppressed_nanos: AtomicU64::new(last_nanos),
+            reported_count: AtomicUsize::new(0),
+            reported_boundary_nanos: AtomicU64::new(first_nanos),
         }
     }
 
@@ -119,6 +142,47 @@ impl SuppressionCounter {
         self.suppressed_count.store(0, Ordering::Release);
         self.first_suppressed_nanos.store(nanos, Ordering::Release);
         self.last_suppressed_nanos.store(nanos, Ordering::Release);
+        self.reported_count.store(0, Ordering::Release);
+        self.reported_boundary_nanos.store(nanos, Ordering::Release);
+    }
+
+    /// Get the number of suppressions already covered by an emitted summary.
+    pub fn reported(&self) -> usize {
+        self.reported_count.load(Ordering::Acquire)
+    }
+
+    /// Atomically claim all suppressions not yet covered by an emitted summary.
+    ///
+    /// Advances the reported mark to the current count and returns the newly
+    /// claimed range, or `None` if there is nothing new to report.
+    ///
+    /// # Thread Safety
+    ///
+    /// The mark is advanced with `fetch_max`, so if two reporters race, exactly
+    /// one of them claims each suppression: the loser observes an already-advanced
+    /// mark and gets `None`. A suppression recorded concurrently with a claim is
+    /// never lost — it is picked up by the next claim.
+    pub fn claim_unreported(&self) -> Option<UnreportedSuppressions> {
+        let count = self.suppressed_count.load(Ordering::Acquire);
+        if count == 0 {
+            return None;
+        }
+
+        let previously_reported = self.reported_count.fetch_max(count, Ordering::AcqRel);
+        if previously_reported >= count {
+            return None;
+        }
+
+        let since_nanos = self.reported_boundary_nanos.load(Ordering::Acquire);
+        let until = self.last_suppressed();
+        self.reported_boundary_nanos
+            .store(Self::instant_to_nanos(until), Ordering::Release);
+
+        Some(UnreportedSuppressions {
+            count: count - previously_reported,
+            since: Self::nanos_to_instant(since_nanos),
+            until,
+        })
     }
 
     /// Get the shared base instant for timestamp calculations.
@@ -224,6 +288,25 @@ impl SuppressionSummary {
         }
     }
 
+    /// Create a summary from a claimed range of unreported suppressions.
+    ///
+    /// `count` and `duration` describe only the claimed range, not the
+    /// all-time totals of the counter.
+    pub fn from_unreported(
+        signature: EventSignature,
+        unreported: UnreportedSuppressions,
+        metadata: Option<EventMetadata>,
+    ) -> Self {
+        Self {
+            signature,
+            count: unreported.count,
+            first_suppressed: unreported.since,
+            last_suppressed: unreported.until,
+            duration: unreported.until.saturating_duration_since(unreported.since),
+            metadata,
+        }
+    }
+
     /// Format the summary as a human-readable message.
     ///
     /// If metadata is available, includes event details.
@@ -308,6 +391,108 @@ mod tests {
 
         counter.reset(now);
         assert_eq!(counter.count(), 0);
+    }
+
+    #[test]
+    fn test_claim_unreported_basic() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        // Nothing to claim on a fresh counter
+        assert!(counter.claim_unreported().is_none());
+
+        counter.record_suppression(now + Duration::from_secs(1));
+        counter.record_suppression(now + Duration::from_secs(2));
+
+        let claim = counter.claim_unreported().expect("should claim 2");
+        assert_eq!(claim.count, 2);
+        assert_eq!(counter.reported(), 2);
+
+        // Nothing new to claim until further suppressions occur
+        assert!(counter.claim_unreported().is_none());
+
+        counter.record_suppression(now + Duration::from_secs(3));
+        let claim = counter.claim_unreported().expect("should claim delta");
+        assert_eq!(claim.count, 1);
+        assert!(counter.claim_unreported().is_none());
+    }
+
+    #[test]
+    fn test_claim_unreported_range_timestamps() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        counter.record_suppression(now + Duration::from_secs(2));
+        let claim = counter.claim_unreported().unwrap();
+        // First claim spans from counter creation to last suppression
+        assert_eq!(claim.since, now);
+        assert_eq!(claim.until, now + Duration::from_secs(2));
+
+        counter.record_suppression(now + Duration::from_secs(5));
+        let claim = counter.claim_unreported().unwrap();
+        // Subsequent claims start at the previous claim's boundary
+        assert_eq!(claim.since, now + Duration::from_secs(2));
+        assert_eq!(claim.until, now + Duration::from_secs(5));
+    }
+
+    #[test]
+    fn test_claim_unreported_concurrent_single_winner() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let now = Instant::now();
+        let counter = Arc::new(SuppressionCounter::new(now));
+        for _ in 0..100 {
+            counter.record_suppression(now);
+        }
+
+        let mut handles = vec![];
+        for _ in 0..8 {
+            let counter = Arc::clone(&counter);
+            handles.push(thread::spawn(move || {
+                counter.claim_unreported().map_or(0, |c| c.count)
+            }));
+        }
+
+        let total: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+        // Every suppression is claimed exactly once across racing reporters
+        assert_eq!(total, 100);
+    }
+
+    #[test]
+    fn test_reset_clears_reported() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        counter.record_suppression(now);
+        counter.claim_unreported().unwrap();
+        assert_eq!(counter.reported(), 1);
+
+        counter.reset(now);
+        assert_eq!(counter.reported(), 0);
+        assert!(counter.claim_unreported().is_none());
+    }
+
+    #[test]
+    fn test_summary_from_unreported() {
+        let sig = EventSignature::simple("INFO", "Test");
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        for i in 1..=9 {
+            counter.record_suppression(now + Duration::from_secs(i));
+        }
+        counter.claim_unreported().unwrap();
+
+        for i in 10..=12 {
+            counter.record_suppression(now + Duration::from_secs(i));
+        }
+        let claim = counter.claim_unreported().unwrap();
+        let summary = SuppressionSummary::from_unreported(sig, claim, None);
+
+        assert_eq!(summary.count, 3);
+        assert_eq!(summary.duration, Duration::from_secs(3));
+        assert_eq!(summary.signature, sig);
     }
 
     #[test]

--- a/src/infrastructure/layer.rs
+++ b/src/infrastructure/layer.rs
@@ -30,13 +30,11 @@ use tracing_subscriber::{layer::Context, Layer};
 /// Events emitted with this target are automatically exempt from throttling to
 /// prevent recursive suppression of summary messages. This target is intentionally
 /// internal and not part of the public API.
-#[cfg(feature = "async")]
 const SUMMARY_TARGET: &str = "tracing_throttle::summary";
 
 #[cfg(feature = "async")]
 use crate::application::emitter::{EmitterHandle, SummaryEmitter};
 
-#[cfg(feature = "async")]
 use crate::domain::summary::SuppressionSummary;
 
 #[cfg(feature = "async")]
@@ -46,8 +44,21 @@ use std::sync::Mutex;
 ///
 /// Takes a reference to a `SuppressionSummary` and emits it as a tracing event.
 /// The function is responsible for choosing the log level and format.
-#[cfg(feature = "async")]
 pub type SummaryFormatter = Arc<dyn Fn(&SuppressionSummary) + Send + Sync + 'static>;
+
+/// Default summary formatter: WARN level with `signature` and `count` fields,
+/// emitted under the throttling-exempt internal summary target.
+fn default_summary_formatter() -> SummaryFormatter {
+    Arc::new(|summary: &SuppressionSummary| {
+        tracing::warn!(
+            target: SUMMARY_TARGET,
+            signature = %summary.signature,
+            count = summary.count,
+            "{}",
+            summary.format_message()
+        );
+    })
+}
 
 /// Error returned when building a TracingRateLimitLayer fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,7 +97,6 @@ pub struct TracingRateLimitLayerBuilder {
     clock: Option<Arc<dyn Clock>>,
     max_signatures: Option<usize>,
     enable_active_emission: bool,
-    #[cfg(feature = "async")]
     summary_formatter: Option<SummaryFormatter>,
     span_context_fields: Vec<String>,
     excluded_fields: BTreeSet<String>,
@@ -262,7 +272,9 @@ impl TracingRateLimitLayerBuilder {
     /// The formatter is responsible for emitting summaries as tracing events.
     /// This allows full control over log level, message format, and structured fields.
     ///
-    /// **Requires the `async` feature.**
+    /// The formatter is used both for periodic summaries (active emission,
+    /// requires the `async` feature) and for episode-end summaries emitted
+    /// when a policy allows an event again after a run of suppressions.
     ///
     /// If not set, a default formatter is used that emits at WARN level with
     /// `signature` and `count` fields.
@@ -286,7 +298,6 @@ impl TracingRateLimitLayerBuilder {
     ///     .build()
     ///     .unwrap();
     /// ```
-    #[cfg(feature = "async")]
     pub fn with_summary_formatter(mut self, formatter: SummaryFormatter) -> Self {
         self.summary_formatter = Some(formatter);
         self
@@ -544,27 +555,20 @@ impl TracingRateLimitLayerBuilder {
         // Let EmitterConfig validate the interval
         let emitter_config = EmitterConfig::new(self.summary_interval)?;
 
+        // Use custom formatter or default
+        let formatter = self
+            .summary_formatter
+            .unwrap_or_else(default_summary_formatter);
+
         #[cfg(feature = "async")]
         let emitter_handle = if self.enable_active_emission {
             let emitter = SummaryEmitter::new(registry, emitter_config);
 
-            // Use custom formatter or default
-            let formatter = self.summary_formatter.unwrap_or_else(|| {
-                Arc::new(|summary: &SuppressionSummary| {
-                    tracing::warn!(
-                        target: SUMMARY_TARGET,
-                        signature = %summary.signature,
-                        count = summary.count,
-                        "{}",
-                        summary.format_message()
-                    );
-                })
-            });
-
+            let emitter_formatter = formatter.clone();
             let handle = emitter.start(
                 move |summaries| {
                     for summary in summaries {
-                        formatter(&summary);
+                        emitter_formatter(&summary);
                     }
                 },
                 false, // Don't emit final summaries on shutdown
@@ -579,6 +583,7 @@ impl TracingRateLimitLayerBuilder {
             span_context_fields: Arc::new(self.span_context_fields),
             excluded_fields: Arc::new(self.excluded_fields),
             exempt_targets: Arc::new(self.exempt_targets),
+            summary_formatter: formatter,
             #[cfg(feature = "async")]
             emitter_handle,
             #[cfg(not(feature = "async"))]
@@ -603,6 +608,7 @@ where
     span_context_fields: Arc<Vec<String>>,
     excluded_fields: Arc<BTreeSet<String>>,
     exempt_targets: Arc<BTreeSet<String>>,
+    summary_formatter: SummaryFormatter,
     #[cfg(feature = "async")]
     emitter_handle: Arc<Mutex<Option<EmitterHandle>>>,
     #[cfg(not(feature = "async"))]
@@ -703,14 +709,23 @@ where
     }
 
     /// Check if an event should be allowed through.
+    ///
+    /// When the policy treats an `Allow` as the end of a suppression episode
+    /// (e.g. time window, exponential backoff), a summary of the suppressions
+    /// that have not yet been reported is emitted through the summary formatter.
     pub fn should_allow(&self, signature: EventSignature) -> bool {
-        matches!(self.limiter.check_event(signature), LimitDecision::Allow)
+        let (decision, episode) = self.limiter.check_event_with_summary(signature);
+        if let Some(summary) = episode {
+            (self.summary_formatter)(&summary);
+        }
+        matches!(decision, LimitDecision::Allow)
     }
 
     /// Check if an event should be allowed through and capture metadata.
     ///
     /// This method stores event metadata on first occurrence so summaries
     /// can show human-readable event details instead of just signature hashes.
+    /// Episode-end summaries are emitted like in [`should_allow`](Self::should_allow).
     ///
     /// **Note:** Only available with the `human-readable` feature flag.
     #[cfg(feature = "human-readable")]
@@ -719,10 +734,13 @@ where
         signature: EventSignature,
         metadata: crate::domain::metadata::EventMetadata,
     ) -> bool {
-        matches!(
-            self.limiter.check_event_with_metadata(signature, metadata),
-            LimitDecision::Allow
-        )
+        let (decision, episode) = self
+            .limiter
+            .check_event_with_metadata_and_summary(signature, metadata);
+        if let Some(summary) = episode {
+            (self.summary_formatter)(&summary);
+        }
+        matches!(decision, LimitDecision::Allow)
     }
 
     /// Get a reference to the underlying limiter.
@@ -813,7 +831,6 @@ impl TracingRateLimitLayer<Arc<ShardedStorage<EventSignature, EventState>>> {
             clock: None,
             max_signatures: Some(10_000),
             enable_active_emission: false,
-            #[cfg(feature = "async")]
             summary_formatter: None,
             span_context_fields: Vec::new(),
             excluded_fields: BTreeSet::new(),
@@ -887,6 +904,7 @@ impl TracingRateLimitLayer<Arc<ShardedStorage<EventSignature, EventState>>> {
             span_context_fields: Arc::new(Vec::new()),
             excluded_fields: Arc::new(BTreeSet::new()),
             exempt_targets: Arc::new(BTreeSet::new()),
+            summary_formatter: default_summary_formatter(),
             #[cfg(feature = "async")]
             emitter_handle: Arc::new(Mutex::new(None)),
             #[cfg(not(feature = "async"))]
@@ -921,7 +939,6 @@ where
         // Exempt our internal summary emission target to prevent recursive throttling.
         // Only the default formatter uses this target; custom formatters are the user's
         // responsibility and are intentionally subject to normal throttling rules.
-        #[cfg(feature = "async")]
         if target == SUMMARY_TARGET {
             return true;
         }
@@ -1363,6 +1380,7 @@ mod tests {
             span_context_fields: Arc::new(Vec::new()),
             excluded_fields: Arc::new(BTreeSet::new()),
             exempt_targets: Arc::new(BTreeSet::new()),
+            summary_formatter: default_summary_formatter(),
             #[cfg(feature = "async")]
             emitter_handle: Arc::new(Mutex::new(None)),
             #[cfg(not(feature = "async"))]
@@ -1563,6 +1581,55 @@ mod tests {
         );
 
         layer.shutdown().await.expect("shutdown failed");
+    }
+
+    /// Regression test for issue #4: episode-ending allows emit one summary
+    /// of the suppressions, and quiet periods produce no further output.
+    #[test]
+    fn test_episode_end_summary_emission() {
+        use crate::infrastructure::mocks::MockClock;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Mutex as StdMutex;
+        use std::time::{Duration, Instant};
+
+        let mock_clock = Arc::new(MockClock::new(Instant::now()));
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&call_count);
+        let last_summary_count = Arc::new(StdMutex::new(0usize));
+        let last_summary_clone = Arc::clone(&last_summary_count);
+
+        let layer = TracingRateLimitLayer::builder()
+            .with_policy(Policy::time_window(1, Duration::from_secs(60)).unwrap())
+            .with_clock(mock_clock.clone())
+            .with_summary_formatter(Arc::new(move |summary| {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+                *last_summary_clone.lock().unwrap() = summary.count;
+            }))
+            .build()
+            .unwrap();
+
+        let sig = EventSignature::simple("INFO", "Initialization step");
+
+        // 1 allowed, 9 suppressed
+        assert!(layer.should_allow(sig));
+        for _ in 0..9 {
+            assert!(!layer.should_allow(sig));
+        }
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+
+        // Window rolls over: the allowing event closes the episode
+        mock_clock.advance(Duration::from_secs(61));
+        assert!(layer.should_allow(sig));
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+        assert_eq!(*last_summary_count.lock().unwrap(), 9);
+
+        // Quiet windows produce no repeated summaries
+        mock_clock.advance(Duration::from_secs(61));
+        assert!(layer.should_allow(sig));
+        mock_clock.advance(Duration::from_secs(61));
+        assert!(layer.should_allow(sig));
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
     }
 
     #[cfg(feature = "async")]

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -97,9 +97,19 @@ async fn test_explicit_shutdown_required() {
 #[tokio::test]
 async fn test_explicit_shutdown_in_application() {
     // Simulate an application with explicit shutdown
+    type Registry = tracing_throttle::SuppressionRegistry<
+        Arc<
+            tracing_throttle::ShardedStorage<
+                tracing_throttle::EventSignature,
+                tracing_throttle::application::registry::EventState,
+            >,
+        >,
+    >;
+
     struct Application {
         _emitter_handle: Option<EmitterHandle>,
         emissions: Arc<Mutex<Vec<usize>>>,
+        registry: Registry,
     }
 
     impl Application {
@@ -121,8 +131,10 @@ async fn test_explicit_shutdown_in_application() {
                 Duration::from_millis(100),
             )
             .unwrap();
-            let emitter =
-                tracing_throttle::application::emitter::SummaryEmitter::new(registry, config);
+            let emitter = tracing_throttle::application::emitter::SummaryEmitter::new(
+                registry.clone(),
+                config,
+            );
 
             let emissions = Arc::new(Mutex::new(Vec::new()));
             let emissions_clone = Arc::clone(&emissions);
@@ -137,7 +149,15 @@ async fn test_explicit_shutdown_in_application() {
             Self {
                 _emitter_handle: Some(handle),
                 emissions,
+                registry,
             }
+        }
+
+        fn record_suppression(&self) {
+            let sig = tracing_throttle::EventSignature::simple("INFO", "App event");
+            self.registry.with_event_state(sig, |state, now| {
+                state.counter.record_suppression(now);
+            });
         }
 
         async fn shutdown(mut self) {
@@ -153,8 +173,11 @@ async fn test_explicit_shutdown_in_application() {
 
     let app = Application::new();
 
-    // Let it run
-    tokio::time::sleep(Duration::from_millis(250)).await;
+    // Let it run, with new suppressions arriving between intervals
+    for _ in 0..4 {
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        app.record_suppression();
+    }
 
     let emissions_before = app.emission_count();
     assert!(emissions_before >= 2);


### PR DESCRIPTION
Close #4 
- Introduced `collect_unreported_summaries` to retrieve and mark unreported suppressions.
- Updated `check_event` methods to return suppression summaries when events are allowed.
- Added support for episode-end summaries in rate limiting policies.
- Enhanced `SuppressionCounter` to track reported suppressions and manage unreported claims.
- Improved tests for summary emissions and suppression behavior.