### PR TITLE
Fix repeated suppression summary emission

### DIFF
--- a/src/application/emitter.rs
+++ b/src/application/emitter.rs
@@ -7,7 +7,10 @@ use crate::application::{
     ports::Storage,
     registry::{EventState, SuppressionRegistry},
 };
-use crate::domain::{signature::EventSignature, summary::SuppressionSummary};
+use crate::domain::{
+    signature::EventSignature,
+    summary::{ClaimedSuppressions, SuppressionSummary},
+};
 use std::time::Duration;
 
 #[cfg(feature = "async")]
@@ -267,6 +270,16 @@ where
     config: EmitterConfig,
 }
 
+struct ClaimedSummary {
+    signature: EventSignature,
+    claim: ClaimedSuppressions,
+}
+
+struct ClaimedSummaryBatch {
+    summaries: Vec<SuppressionSummary>,
+    claims: Vec<ClaimedSummary>,
+}
+
 impl<S> SummaryEmitter<S>
 where
     S: Storage<EventSignature, EventState> + Clone,
@@ -276,33 +289,81 @@ where
         Self { registry, config }
     }
 
-    /// Collect current suppression summaries.
+    /// Collect suppression summaries for newly reported suppressions.
     ///
-    /// Returns summaries for all events that have been suppressed at least
-    /// `min_count` times.
+    /// Returns summaries for events that have accumulated at least `min_count`
+    /// suppressions since their previous emission.
     pub fn collect_summaries(&self) -> Vec<SuppressionSummary> {
+        self.collect_claimed_summaries().summaries
+    }
+
+    fn collect_claimed_summaries(&self) -> ClaimedSummaryBatch {
         let mut summaries = Vec::new();
+        let mut claims = Vec::new();
         let min_count = self.config.min_count;
 
-        self.registry.for_each(|signature, state| {
-            let count = state.counter.count();
-
-            if count >= min_count {
+        self.registry.cleanup(|signature, state| {
+            if let Some(claim) = state.counter.claim_unreported(min_count) {
                 #[cfg(feature = "human-readable")]
-                let summary = SuppressionSummary::from_counter_with_metadata(
+                let summary = SuppressionSummary::from_claim_with_metadata(
                     *signature,
-                    &state.counter,
+                    claim.clone(),
                     state.metadata.clone(),
                 );
 
                 #[cfg(not(feature = "human-readable"))]
-                let summary = SuppressionSummary::from_counter(*signature, &state.counter);
+                let summary = SuppressionSummary::from_claim(*signature, claim.clone());
 
+                claims.push(ClaimedSummary {
+                    signature: *signature,
+                    claim,
+                });
                 summaries.push(summary);
             }
+
+            true
         });
 
-        summaries
+        ClaimedSummaryBatch { summaries, claims }
+    }
+
+    fn rollback_claimed_summaries(&self, claims: &[ClaimedSummary]) {
+        if claims.is_empty() {
+            return;
+        }
+
+        self.registry.cleanup(|signature, state| {
+            for claim in claims {
+                if claim.signature == *signature {
+                    state.counter.rollback_claim(&claim.claim);
+                }
+            }
+
+            true
+        });
+    }
+
+    fn emit_claimed_summaries<F>(&self, batch: ClaimedSummaryBatch, emit_fn: &mut F) -> bool
+    where
+        F: FnMut(Vec<SuppressionSummary>),
+    {
+        if batch.summaries.is_empty() {
+            return true;
+        }
+
+        let claims = batch.claims;
+        let summaries = batch.summaries;
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            emit_fn(summaries);
+        }));
+
+        if result.is_err() {
+            self.rollback_claimed_summaries(&claims);
+            false
+        } else {
+            true
+        }
     }
 
     /// Start emitting summaries periodically (async version).
@@ -320,9 +381,9 @@ where
     ///
     /// # Cancellation Safety
     ///
-    /// The spawned task is cancellation-safe:
-    /// - `collect_summaries()` reads atomically from storage without mutations
-    /// - If cancelled during emission, the next startup will see correct state
+    /// The spawned task is designed to shut down cleanly:
+    /// - `collect_summaries()` atomically claims unreported suppressions
+    /// - Claimed suppressions are not emitted again on later ticks
     /// - Panics in `emit_fn` are caught and don't abort the task
     /// - The `emit_fn` closure should be cancellation-safe (avoid holding locks across `.await`)
     ///
@@ -381,37 +442,21 @@ where
                         if *shutdown_rx.borrow_and_update() {
                             // Emit final summaries if requested
                             if emit_final {
-                                let summaries = self.collect_summaries();
-                                if !summaries.is_empty() {
-                                    // Panic safety for final emission too
-                                    // Note: summaries will be properly dropped even if emit_fn panics
-                                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                        emit_fn(summaries);
-                                    }));
-
-                                    if result.is_err() {
-                                        #[cfg(debug_assertions)]
-                                        eprintln!("Warning: emit_fn panicked during final emission");
-                                    }
+                                let batch = self.collect_claimed_summaries();
+                                if !self.emit_claimed_summaries(batch, &mut emit_fn) {
+                                    #[cfg(debug_assertions)]
+                                    eprintln!("Warning: emit_fn panicked during final emission");
                                 }
                             }
                             break;
                         }
                     }
                     _ = ticker.tick() => {
-                        let summaries = self.collect_summaries();
-                        if !summaries.is_empty() {
-                            // Panic safety: catch panics in emit_fn to prevent task abort
-                            // Note: summaries will be properly dropped even if emit_fn panics
-                            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                emit_fn(summaries);
-                            }));
-
-                            if result.is_err() {
-                                // emit_fn panicked - summaries were dropped, continue running
-                                #[cfg(debug_assertions)]
-                                eprintln!("Warning: emit_fn panicked during emission");
-                            }
+                        let batch = self.collect_claimed_summaries();
+                        if !self.emit_claimed_summaries(batch, &mut emit_fn) {
+                            // emit_fn panicked - claims were rolled back, continue running
+                            #[cfg(debug_assertions)]
+                            eprintln!("Warning: emit_fn panicked during emission");
                         }
                     }
                 }
@@ -450,7 +495,7 @@ mod tests {
         let policy = Policy::count_based(100).unwrap();
         let registry = SuppressionRegistry::new(storage, clock, policy);
         let config = EmitterConfig::default();
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         let summaries = emitter.collect_summaries();
         assert!(summaries.is_empty());
@@ -475,7 +520,7 @@ mod tests {
             });
         }
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
         let summaries = emitter.collect_summaries();
 
         assert_eq!(summaries.len(), 3);
@@ -485,6 +530,12 @@ mod tests {
         assert!(counts.contains(&5));
         assert!(counts.contains(&10));
         assert!(counts.contains(&15));
+
+        let summaries = emitter.collect_summaries();
+        assert!(
+            summaries.is_empty(),
+            "already emitted summaries should not be emitted again"
+        );
     }
 
     #[test]
@@ -511,12 +562,80 @@ mod tests {
             }
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
         let summaries = emitter.collect_summaries();
 
         // Only the high-count event should be included
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].count, 14);
+
+        let summaries = emitter.collect_summaries();
+        assert!(
+            summaries.is_empty(),
+            "claimed summaries should not be emitted again"
+        );
+    }
+
+    #[test]
+    fn test_min_count_accumulates_unreported_suppressions() {
+        let storage = Arc::new(ShardedStorage::new());
+        let clock = Arc::new(SystemClock::new());
+        let policy = Policy::count_based(100).unwrap();
+        let registry = SuppressionRegistry::new(storage, clock, policy);
+        let config = EmitterConfig::default().with_min_count(10);
+
+        let sig = EventSignature::simple("INFO", "Accumulated");
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..4 {
+                state.counter.record_suppression(now);
+            }
+        });
+
+        let emitter = SummaryEmitter::new(registry.clone(), config);
+        assert!(emitter.collect_summaries().is_empty());
+
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..6 {
+                state.counter.record_suppression(now);
+            }
+        });
+
+        let summaries = emitter.collect_summaries();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].count, 10);
+    }
+
+    #[test]
+    fn test_collect_summaries_reports_only_new_suppressions() {
+        let storage = Arc::new(ShardedStorage::new());
+        let clock = Arc::new(SystemClock::new());
+        let policy = Policy::count_based(100).unwrap();
+        let registry = SuppressionRegistry::new(storage, clock, policy);
+        let config = EmitterConfig::default();
+
+        let sig = EventSignature::simple("INFO", "Delta");
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..5 {
+                state.counter.record_suppression(now);
+            }
+        });
+
+        let emitter = SummaryEmitter::new(registry.clone(), config);
+        let summaries = emitter.collect_summaries();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].count, 5);
+
+        assert!(emitter.collect_summaries().is_empty());
+
+        registry.with_event_state(sig, |state, now| {
+            for _ in 0..3 {
+                state.counter.record_suppression(now);
+            }
+        });
+
+        let summaries = emitter.collect_summaries();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].count, 3);
     }
 
     #[cfg(feature = "async")]
@@ -536,7 +655,7 @@ mod tests {
             state.counter.record_suppression(now);
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         // Track emissions
         let emissions = Arc::new(Mutex::new(Vec::new()));
@@ -554,9 +673,9 @@ mod tests {
 
         handle.shutdown().await.expect("shutdown failed");
 
-        // Should have emitted at least once
+        // Should emit the suppression once, then stay quiet until new suppressions arrive.
         let emission_count = emissions.lock().unwrap().len();
-        assert!(emission_count >= 2);
+        assert_eq!(emission_count, 1);
     }
 
     #[test]
@@ -592,7 +711,7 @@ mod tests {
             state.counter.record_suppression(now);
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         let emissions = Arc::new(Mutex::new(0));
         let emissions_clone = Arc::clone(&emissions);
@@ -713,7 +832,7 @@ mod tests {
         let registry = SuppressionRegistry::new(storage, clock, policy);
         let config = EmitterConfig::new(Duration::from_millis(100)).unwrap();
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
         let handle = emitter.start(|_| {}, false);
 
         // Should be running
@@ -792,6 +911,7 @@ mod tests {
     #[tokio::test]
     async fn test_panic_in_emit_fn() {
         use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Mutex;
 
         let storage = Arc::new(ShardedStorage::new());
         let clock = Arc::new(SystemClock::new());
@@ -807,13 +927,17 @@ mod tests {
             }
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = Arc::clone(&call_count);
+        let emitted_counts = Arc::new(Mutex::new(Vec::new()));
+        let emitted_counts_clone = Arc::clone(&emitted_counts);
 
         let handle = emitter.start(
-            move |_summaries| {
+            move |summaries| {
+                let total: usize = summaries.iter().map(|summary| summary.count).sum();
+                emitted_counts_clone.lock().unwrap().push(total);
                 let count = call_count_clone.fetch_add(1, Ordering::SeqCst);
 
                 // Panic on first call, succeed on subsequent calls
@@ -825,8 +949,8 @@ mod tests {
             false,
         );
 
-        // Let it emit multiple times - first should panic, rest should succeed
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // The first emission panics and rolls back; the next tick retries the same batch.
+        tokio::time::sleep(Duration::from_millis(150)).await;
 
         handle.shutdown().await.expect("shutdown failed");
 
@@ -836,6 +960,14 @@ mod tests {
             final_count > 1,
             "Task should continue after panic in emit_fn"
         );
+
+        let emitted_counts = emitted_counts.lock().unwrap();
+        assert!(
+            emitted_counts.len() > 1,
+            "Panicked emission should be retried"
+        );
+        assert_eq!(emitted_counts[0], 5);
+        assert_eq!(emitted_counts[1], 5);
     }
 
     #[cfg(feature = "async")]
@@ -854,7 +986,7 @@ mod tests {
             state.counter.record_suppression(now);
         });
 
-        let emitter = SummaryEmitter::new(registry, config);
+        let emitter = SummaryEmitter::new(registry.clone(), config);
 
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = Arc::clone(&call_count);
@@ -867,8 +999,15 @@ mod tests {
             false,
         );
 
-        // Let it run and panic multiple times
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::sleep(Duration::from_millis(70)).await;
+
+        for _ in 0..3 {
+            let sig = EventSignature::simple("INFO", "Test");
+            registry.with_event_state(sig, |state, now| {
+                state.counter.record_suppression(now);
+            });
+            tokio::time::sleep(Duration::from_millis(40)).await;
+        }
 
         handle.shutdown().await.expect("shutdown failed");
 

--- a/src/application/registry.rs
+++ b/src/application/registry.rs
@@ -68,12 +68,67 @@ impl EventState {
         first_suppressed: Instant,
         last_suppressed: Instant,
     ) -> Self {
+        Self::from_snapshot_with_reported(
+            policy,
+            suppressed_count,
+            0,
+            first_suppressed,
+            last_suppressed,
+            first_suppressed,
+        )
+    }
+
+    /// Create event state from a snapshot including reported suppressions.
+    ///
+    /// This is used by storage backends to persist active-emission progress.
+    #[cfg(feature = "redis-storage")]
+    pub fn from_snapshot_with_reported(
+        policy: Policy,
+        suppressed_count: usize,
+        reported_count: usize,
+        first_suppressed: Instant,
+        last_suppressed: Instant,
+        last_reported: Instant,
+    ) -> Self {
+        let first_unreported = if reported_count == 0 {
+            first_suppressed
+        } else {
+            last_reported
+        };
+
+        Self::from_snapshot_with_reported_and_first_unreported(
+            policy,
+            suppressed_count,
+            reported_count,
+            first_suppressed,
+            last_suppressed,
+            last_reported,
+            first_unreported,
+        )
+    }
+
+    /// Create event state from a snapshot including reported and unreported cursors.
+    ///
+    /// This is used by storage backends to persist active-emission progress.
+    #[cfg(feature = "redis-storage")]
+    pub fn from_snapshot_with_reported_and_first_unreported(
+        policy: Policy,
+        suppressed_count: usize,
+        reported_count: usize,
+        first_suppressed: Instant,
+        last_suppressed: Instant,
+        last_reported: Instant,
+        first_unreported: Instant,
+    ) -> Self {
         Self {
             policy,
-            counter: SuppressionCounter::from_snapshot(
+            counter: SuppressionCounter::from_snapshot_with_reported_and_first_unreported(
                 suppressed_count,
+                reported_count,
                 first_suppressed,
                 last_suppressed,
+                last_reported,
+                first_unreported,
             ),
             metadata: None,
         }

--- a/src/domain/summary.rs
+++ b/src/domain/summary.rs
@@ -4,31 +4,49 @@
 //! periodic summaries for emission.
 
 use crate::domain::{metadata::EventMetadata, signature::EventSignature};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    Mutex, MutexGuard,
+};
 use std::time::{Duration, Instant};
 
 /// Thread-safe counter for tracking suppressed events.
 ///
-/// Uses atomics for lock-free concurrent updates in high-throughput scenarios.
+/// Uses atomics for cheap reads and a short critical section for updates that
+/// must keep count and timestamp cursors consistent.
 #[derive(Debug)]
 pub struct SuppressionCounter {
+    /// Guards multi-field updates to count and timestamp cursors
+    state_lock: Mutex<()>,
     /// Total number of times this event was suppressed
     suppressed_count: AtomicUsize,
+    /// Total number of suppressions already included in emitted summaries
+    reported_count: AtomicUsize,
     /// Timestamp of first suppression (nanoseconds since epoch)
     first_suppressed_nanos: AtomicU64,
     /// Timestamp of last suppression (nanoseconds since epoch)
     last_suppressed_nanos: AtomicU64,
+    /// Timestamp of the last suppression included in an emitted summary
+    last_reported_nanos: AtomicU64,
+    /// Timestamp of the first suppression not yet included in an emitted summary
+    first_unreported_nanos: AtomicU64,
 }
 
 impl Clone for SuppressionCounter {
     fn clone(&self) -> Self {
         Self {
+            state_lock: Mutex::new(()),
             suppressed_count: AtomicUsize::new(self.suppressed_count.load(Ordering::Relaxed)),
+            reported_count: AtomicUsize::new(self.reported_count.load(Ordering::Relaxed)),
             first_suppressed_nanos: AtomicU64::new(
                 self.first_suppressed_nanos.load(Ordering::Relaxed),
             ),
             last_suppressed_nanos: AtomicU64::new(
                 self.last_suppressed_nanos.load(Ordering::Relaxed),
+            ),
+            last_reported_nanos: AtomicU64::new(self.last_reported_nanos.load(Ordering::Relaxed)),
+            first_unreported_nanos: AtomicU64::new(
+                self.first_unreported_nanos.load(Ordering::Relaxed),
             ),
         }
     }
@@ -39,9 +57,13 @@ impl SuppressionCounter {
     pub fn new(initial_timestamp: Instant) -> Self {
         let nanos = Self::instant_to_nanos(initial_timestamp);
         Self {
+            state_lock: Mutex::new(()),
             suppressed_count: AtomicUsize::new(0),
+            reported_count: AtomicUsize::new(0),
             first_suppressed_nanos: AtomicU64::new(nanos),
             last_suppressed_nanos: AtomicU64::new(nanos),
+            last_reported_nanos: AtomicU64::new(nanos),
+            first_unreported_nanos: AtomicU64::new(nanos),
         }
     }
 
@@ -54,20 +76,88 @@ impl SuppressionCounter {
         first_suppressed: Instant,
         last_suppressed: Instant,
     ) -> Self {
+        Self::from_snapshot_with_reported(
+            suppressed_count,
+            0,
+            first_suppressed,
+            last_suppressed,
+            first_suppressed,
+        )
+    }
+
+    /// Create a counter from a snapshot including reported suppressions.
+    ///
+    /// This is used by storage backends to persist active-emission progress.
+    #[cfg(feature = "redis-storage")]
+    pub fn from_snapshot_with_reported(
+        suppressed_count: usize,
+        reported_count: usize,
+        first_suppressed: Instant,
+        last_suppressed: Instant,
+        last_reported: Instant,
+    ) -> Self {
+        let first_unreported = if reported_count == 0 {
+            first_suppressed
+        } else {
+            last_reported
+        };
+
+        Self::from_snapshot_with_reported_and_first_unreported(
+            suppressed_count,
+            reported_count,
+            first_suppressed,
+            last_suppressed,
+            last_reported,
+            first_unreported,
+        )
+    }
+
+    /// Create a counter from a snapshot including reported and unreported cursors.
+    ///
+    /// This is used by storage backends to preserve delta-summary timestamps.
+    #[cfg(feature = "redis-storage")]
+    pub fn from_snapshot_with_reported_and_first_unreported(
+        suppressed_count: usize,
+        reported_count: usize,
+        first_suppressed: Instant,
+        last_suppressed: Instant,
+        last_reported: Instant,
+        first_unreported: Instant,
+    ) -> Self {
         let first_nanos = Self::instant_to_nanos(first_suppressed);
         let last_nanos = Self::instant_to_nanos(last_suppressed);
+        let last_reported_nanos = Self::instant_to_nanos(last_reported);
+        let first_unreported_nanos = Self::instant_to_nanos(first_unreported);
+        let reported_count = reported_count.min(suppressed_count);
+
         Self {
+            state_lock: Mutex::new(()),
             suppressed_count: AtomicUsize::new(suppressed_count),
+            reported_count: AtomicUsize::new(reported_count),
             first_suppressed_nanos: AtomicU64::new(first_nanos),
             last_suppressed_nanos: AtomicU64::new(last_nanos),
+            last_reported_nanos: AtomicU64::new(last_reported_nanos),
+            first_unreported_nanos: AtomicU64::new(first_unreported_nanos),
         }
     }
 
     /// Record a new suppression event.
     pub fn record_suppression(&self, timestamp: Instant) {
-        // Use AcqRel for fetch_add to synchronize with other threads
-        self.suppressed_count.fetch_add(1, Ordering::AcqRel);
+        let _guard = self.lock_state();
         let nanos = Self::instant_to_nanos(timestamp);
+
+        // Use AcqRel for fetch_add to synchronize with other threads
+        let previous_count = self.suppressed_count.fetch_add(1, Ordering::AcqRel);
+        let reported_count = self.reported_count.load(Ordering::Acquire);
+
+        if previous_count == 0 {
+            self.first_suppressed_nanos.store(nanos, Ordering::Release);
+        }
+
+        if previous_count == reported_count {
+            self.first_unreported_nanos.store(nanos, Ordering::Release);
+        }
+
         // Use Release to ensure timestamp update is visible
         self.last_suppressed_nanos.store(nanos, Ordering::Release);
     }
@@ -76,6 +166,82 @@ impl SuppressionCounter {
     pub fn count(&self) -> usize {
         // Use Acquire to synchronize with Release/AcqRel operations
         self.suppressed_count.load(Ordering::Acquire)
+    }
+
+    /// Get the number of suppressions already included in emitted summaries.
+    pub fn reported_count(&self) -> usize {
+        self.reported_count.load(Ordering::Acquire)
+    }
+
+    /// Get the number of suppressions not yet included in emitted summaries.
+    pub fn unreported_count(&self) -> usize {
+        self.count().saturating_sub(self.reported_count())
+    }
+
+    /// Claim unreported suppressions for summary emission.
+    ///
+    /// Returns a snapshot of newly reported suppressions if at least `min_count`
+    /// suppressions have accumulated since the last successful claim.
+    pub fn claim_unreported(&self, min_count: usize) -> Option<ClaimedSuppressions> {
+        let _guard = self.lock_state();
+        let min_count = min_count.max(1);
+
+        let total_count = self.count();
+        let already_reported = self.reported_count();
+        let unreported_count = total_count.saturating_sub(already_reported);
+
+        if unreported_count < min_count {
+            return None;
+        }
+
+        let first_nanos = self.first_unreported_nanos.load(Ordering::Acquire);
+        let previous_last_reported_nanos = self.last_reported_nanos.load(Ordering::Acquire);
+        let last_nanos = self.last_suppressed_nanos.load(Ordering::Acquire);
+
+        self.reported_count.store(total_count, Ordering::Release);
+        self.last_reported_nanos
+            .store(last_nanos, Ordering::Release);
+        self.first_unreported_nanos
+            .store(last_nanos, Ordering::Release);
+
+        let first_suppressed = Self::nanos_to_instant(first_nanos);
+        let last_suppressed = Self::nanos_to_instant(last_nanos);
+
+        Some(ClaimedSuppressions {
+            previous_reported_count: already_reported,
+            previous_last_reported: Self::nanos_to_instant(previous_last_reported_nanos),
+            count: unreported_count,
+            total_count,
+            first_suppressed,
+            last_suppressed,
+            duration: last_suppressed.saturating_duration_since(first_suppressed),
+        })
+    }
+
+    /// Roll back a previously claimed summary.
+    ///
+    /// If a later claim has already advanced the reported cursor, this rewinds to
+    /// the older claim's starting point. That may cause a later summary to be
+    /// emitted again, but prevents suppressions from being lost after a failed
+    /// emission.
+    pub fn rollback_claim(&self, claim: &ClaimedSuppressions) -> bool {
+        let _guard = self.lock_state();
+        let previous_last_reported_nanos = Self::instant_to_nanos(claim.previous_last_reported);
+        let first_unreported_nanos = Self::instant_to_nanos(claim.first_suppressed);
+
+        let current_reported = self.reported_count();
+
+        if current_reported < claim.total_count {
+            return current_reported == claim.previous_reported_count;
+        }
+
+        self.reported_count
+            .store(claim.previous_reported_count, Ordering::Release);
+        self.last_reported_nanos
+            .store(previous_last_reported_nanos, Ordering::Release);
+        self.first_unreported_nanos
+            .store(first_unreported_nanos, Ordering::Release);
+        true
     }
 
     /// Get the timestamp of the first suppression.
@@ -92,13 +258,28 @@ impl SuppressionCounter {
         Self::nanos_to_instant(nanos)
     }
 
+    /// Get the timestamp of the last reported suppression.
+    pub fn last_reported(&self) -> Instant {
+        let nanos = self.last_reported_nanos.load(Ordering::Acquire);
+        Self::nanos_to_instant(nanos)
+    }
+
+    /// Get the timestamp of the first unreported suppression.
+    pub fn first_unreported(&self) -> Instant {
+        let nanos = self.first_unreported_nanos.load(Ordering::Acquire);
+        Self::nanos_to_instant(nanos)
+    }
+
     /// Get a snapshot of the current state (for serialization).
     #[cfg(feature = "redis-storage")]
     pub fn snapshot(&self) -> super::summary::SuppressionSnapshot {
         super::summary::SuppressionSnapshot {
             suppressed_count: self.count(),
+            reported_count: self.reported_count(),
             first_suppressed: self.first_suppressed(),
             last_suppressed: self.last_suppressed(),
+            last_reported: self.last_reported(),
+            first_unreported: self.first_unreported(),
         }
     }
 
@@ -114,11 +295,15 @@ impl SuppressionCounter {
     ///
     /// If you need atomic reset semantics, ensure no concurrent access during reset.
     pub fn reset(&self, timestamp: Instant) {
+        let _guard = self.lock_state();
         let nanos = Self::instant_to_nanos(timestamp);
         // Use Release for visibility
         self.suppressed_count.store(0, Ordering::Release);
+        self.reported_count.store(0, Ordering::Release);
         self.first_suppressed_nanos.store(nanos, Ordering::Release);
         self.last_suppressed_nanos.store(nanos, Ordering::Release);
+        self.last_reported_nanos.store(nanos, Ordering::Release);
+        self.first_unreported_nanos.store(nanos, Ordering::Release);
     }
 
     /// Get the shared base instant for timestamp calculations.
@@ -127,6 +312,12 @@ impl SuppressionCounter {
     fn base_instant() -> &'static Instant {
         static BASE: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
         BASE.get_or_init(Instant::now)
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, ()> {
+        self.state_lock
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
     }
 
     /// Convert Instant to nanoseconds for atomic storage.
@@ -159,13 +350,35 @@ impl SuppressionCounter {
     }
 }
 
+/// Suppressions claimed for one summary emission.
+#[derive(Debug, Clone)]
+pub struct ClaimedSuppressions {
+    /// Reported count before this claim
+    pub previous_reported_count: usize,
+    /// Last reported timestamp before this claim
+    pub previous_last_reported: Instant,
+    /// Number of newly reported suppressions
+    pub count: usize,
+    /// Total suppression count after this claim
+    pub total_count: usize,
+    /// Start of the claimed suppression period
+    pub first_suppressed: Instant,
+    /// End of the claimed suppression period
+    pub last_suppressed: Instant,
+    /// Duration covered by this claim
+    pub duration: Duration,
+}
+
 /// A snapshot of suppression counter state (for serialization).
 #[cfg(feature = "redis-storage")]
 #[derive(Debug, Clone)]
 pub struct SuppressionSnapshot {
     pub suppressed_count: usize,
+    pub reported_count: usize,
     pub first_suppressed: Instant,
     pub last_suppressed: Instant,
+    pub last_reported: Instant,
+    pub first_unreported: Instant,
 }
 
 /// A summary of suppressed events for a particular signature.
@@ -204,6 +417,18 @@ impl SuppressionSummary {
         }
     }
 
+    /// Create a summary from claimed suppressions.
+    pub fn from_claim(signature: EventSignature, claim: ClaimedSuppressions) -> Self {
+        Self {
+            signature,
+            count: claim.count,
+            first_suppressed: claim.first_suppressed,
+            last_suppressed: claim.last_suppressed,
+            duration: claim.duration,
+            metadata: None,
+        }
+    }
+
     /// Create a summary from a counter with metadata.
     pub fn from_counter_with_metadata(
         signature: EventSignature,
@@ -220,6 +445,22 @@ impl SuppressionSummary {
             first_suppressed: first,
             last_suppressed: last,
             duration,
+            metadata,
+        }
+    }
+
+    /// Create a summary from claimed suppressions with metadata.
+    pub fn from_claim_with_metadata(
+        signature: EventSignature,
+        claim: ClaimedSuppressions,
+        metadata: Option<EventMetadata>,
+    ) -> Self {
+        Self {
+            signature,
+            count: claim.count,
+            first_suppressed: claim.first_suppressed,
+            last_suppressed: claim.last_suppressed,
+            duration: claim.duration,
             metadata,
         }
     }
@@ -270,12 +511,148 @@ mod tests {
         let counter = SuppressionCounter::new(now);
 
         assert_eq!(counter.count(), 0);
+        assert_eq!(counter.reported_count(), 0);
+        assert_eq!(counter.unreported_count(), 0);
 
         counter.record_suppression(now);
         assert_eq!(counter.count(), 1);
+        assert_eq!(counter.unreported_count(), 1);
 
         counter.record_suppression(now);
         assert_eq!(counter.count(), 2);
+        assert_eq!(counter.unreported_count(), 2);
+    }
+
+    #[test]
+    fn test_claim_unreported_suppressions() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        counter.record_suppression(now);
+        counter.record_suppression(now);
+
+        let claim = counter.claim_unreported(1).expect("claim should exist");
+        assert_eq!(claim.count, 2);
+        assert_eq!(claim.total_count, 2);
+        assert_eq!(counter.reported_count(), 2);
+        assert_eq!(counter.unreported_count(), 0);
+
+        assert!(
+            counter.claim_unreported(1).is_none(),
+            "already claimed suppressions should not be claimed again"
+        );
+
+        counter.record_suppression(now);
+        let claim = counter.claim_unreported(1).expect("new claim should exist");
+        assert_eq!(claim.count, 1);
+        assert_eq!(claim.total_count, 3);
+    }
+
+    #[test]
+    fn test_claim_unreported_uses_first_new_suppression_timestamp() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        counter.record_suppression(now + Duration::from_secs(1));
+        let first_claim = counter.claim_unreported(1).expect("claim should exist");
+        assert_eq!(first_claim.first_suppressed, now + Duration::from_secs(1));
+        assert_eq!(first_claim.last_suppressed, now + Duration::from_secs(1));
+
+        counter.record_suppression(now + Duration::from_secs(60));
+        let second_claim = counter.claim_unreported(1).expect("claim should exist");
+        assert_eq!(second_claim.count, 1);
+        assert_eq!(second_claim.first_suppressed, now + Duration::from_secs(60));
+        assert_eq!(second_claim.last_suppressed, now + Duration::from_secs(60));
+        assert_eq!(second_claim.duration, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_claim_unreported_respects_min_count() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        for _ in 0..4 {
+            counter.record_suppression(now);
+        }
+
+        assert!(counter.claim_unreported(5).is_none());
+        assert_eq!(counter.reported_count(), 0);
+        assert_eq!(counter.unreported_count(), 4);
+
+        counter.record_suppression(now);
+        let claim = counter.claim_unreported(5).expect("claim should exist");
+        assert_eq!(claim.count, 5);
+        assert_eq!(counter.reported_count(), 5);
+    }
+
+    #[test]
+    fn test_claim_unreported_min_count_zero_requires_suppressions() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        assert!(
+            counter.claim_unreported(0).is_none(),
+            "zero min_count should not create an empty claim"
+        );
+
+        counter.record_suppression(now);
+        let claim = counter.claim_unreported(0).expect("claim should exist");
+        assert_eq!(claim.count, 1);
+
+        assert!(
+            counter.claim_unreported(0).is_none(),
+            "reported suppressions should not create a zero-count claim"
+        );
+    }
+
+    #[test]
+    fn test_rollback_claim_restores_unreported_suppressions() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        counter.record_suppression(now);
+        counter.record_suppression(now);
+
+        let claim = counter.claim_unreported(1).expect("claim should exist");
+        assert_eq!(counter.reported_count(), 2);
+        assert_eq!(counter.unreported_count(), 0);
+
+        assert!(counter.rollback_claim(&claim));
+        assert_eq!(counter.reported_count(), 0);
+        assert_eq!(counter.unreported_count(), 2);
+
+        let claim = counter
+            .claim_unreported(1)
+            .expect("rolled back suppressions should be claimable again");
+        assert_eq!(claim.count, 2);
+    }
+
+    #[test]
+    fn test_rollback_superseded_claim_restores_full_unreported_range() {
+        let now = Instant::now();
+        let counter = SuppressionCounter::new(now);
+
+        counter.record_suppression(now + Duration::from_secs(1));
+        counter.record_suppression(now + Duration::from_secs(2));
+        let first_claim = counter.claim_unreported(1).expect("claim should exist");
+
+        counter.record_suppression(now + Duration::from_secs(3));
+        let second_claim = counter
+            .claim_unreported(1)
+            .expect("later claim should exist");
+        assert_eq!(second_claim.count, 1);
+        assert_eq!(counter.reported_count(), 3);
+
+        assert!(counter.rollback_claim(&first_claim));
+        assert_eq!(counter.reported_count(), 0);
+        assert_eq!(counter.unreported_count(), 3);
+
+        let retry_claim = counter
+            .claim_unreported(1)
+            .expect("rolled back suppressions should retry");
+        assert_eq!(retry_claim.count, 3);
+        assert_eq!(retry_claim.first_suppressed, now + Duration::from_secs(1));
+        assert_eq!(retry_claim.last_suppressed, now + Duration::from_secs(3));
     }
 
     #[test]
@@ -290,8 +667,8 @@ mod tests {
         let first = counter.first_suppressed();
         let last = counter.last_suppressed();
 
-        // First should be approximately start
-        assert!(first.saturating_duration_since(start) < Duration::from_millis(5));
+        // First should be approximately the first recorded suppression
+        assert!(first.saturating_duration_since(later) < Duration::from_millis(5));
 
         // Last should be approximately later
         assert!(last.saturating_duration_since(later) < Duration::from_millis(5));
@@ -308,6 +685,8 @@ mod tests {
 
         counter.reset(now);
         assert_eq!(counter.count(), 0);
+        assert_eq!(counter.reported_count(), 0);
+        assert_eq!(counter.unreported_count(), 0);
     }
 
     #[test]
@@ -316,13 +695,15 @@ mod tests {
         let start = Instant::now();
         let counter = SuppressionCounter::new(start);
 
+        let first = Instant::now();
+        counter.record_suppression(first);
         thread::sleep(Duration::from_millis(10));
         counter.record_suppression(Instant::now());
 
         let summary = SuppressionSummary::from_counter(sig, &counter);
 
         assert_eq!(summary.signature, sig);
-        assert_eq!(summary.count, 1);
+        assert_eq!(summary.count, 2);
         assert!(summary.duration >= Duration::from_millis(10));
     }
 
@@ -426,6 +807,7 @@ mod tests {
         let cloned = counter.clone();
 
         assert_eq!(counter.count(), cloned.count());
+        assert_eq!(counter.reported_count(), cloned.reported_count());
         assert_eq!(counter.first_suppressed(), cloned.first_suppressed());
         assert_eq!(counter.last_suppressed(), cloned.last_suppressed());
     }
@@ -438,10 +820,13 @@ mod tests {
 
         // Modify counter1
         counter1.record_suppression(now);
+        let _claim = counter1.claim_unreported(1);
 
         // counter2 should not be affected
         assert_eq!(counter1.count(), 1);
+        assert_eq!(counter1.reported_count(), 1);
         assert_eq!(counter2.count(), 0);
+        assert_eq!(counter2.reported_count(), 0);
     }
 
     #[test]
@@ -549,10 +934,11 @@ mod tests {
             counter.record_suppression(timestamp);
         }
 
-        // First timestamp should be preserved
+        // First recorded suppression timestamp should be preserved
         let first = counter.first_suppressed();
-        let duration_from_start = first.duration_since(start);
-        assert!(duration_from_start < Duration::from_millis(10));
+        let expected_first = start + Duration::from_millis(100);
+        let duration_from_first = first.duration_since(expected_first);
+        assert!(duration_from_first < Duration::from_millis(10));
 
         // Last timestamp should be the most recent
         let last = counter.last_suppressed();
@@ -670,6 +1056,8 @@ mod tests {
 
         counter.record_suppression(now + Duration::from_secs(1));
         counter.record_suppression(now + Duration::from_secs(2));
+        let _claim = counter.claim_unreported(1);
+        counter.record_suppression(now + Duration::from_secs(3));
 
         let snapshot = counter.snapshot();
 
@@ -680,6 +1068,36 @@ mod tests {
         );
 
         assert_eq!(counter.count(), restored.count());
+        assert_eq!(0, restored.reported_count());
+
+        let restored_with_reported = SuppressionCounter::from_snapshot_with_reported(
+            snapshot.suppressed_count,
+            snapshot.reported_count,
+            snapshot.first_suppressed,
+            snapshot.last_suppressed,
+            snapshot.last_reported,
+        );
+        assert_eq!(counter.count(), restored_with_reported.count());
+        assert_eq!(
+            counter.reported_count(),
+            restored_with_reported.reported_count()
+        );
+
+        let restored_with_unreported =
+            SuppressionCounter::from_snapshot_with_reported_and_first_unreported(
+                snapshot.suppressed_count,
+                snapshot.reported_count,
+                snapshot.first_suppressed,
+                snapshot.last_suppressed,
+                snapshot.last_reported,
+                snapshot.first_unreported,
+            );
+        assert_eq!(counter.count(), restored_with_unreported.count());
+        assert_eq!(
+            counter.reported_count(),
+            restored_with_unreported.reported_count()
+        );
+
         // Note: timestamps may have slight differences due to serialization precision
         let first_diff = counter
             .first_suppressed()
@@ -687,8 +1105,16 @@ mod tests {
         let last_diff = counter
             .last_suppressed()
             .duration_since(restored.last_suppressed());
+        let last_reported_diff = counter
+            .last_reported()
+            .duration_since(restored_with_reported.last_reported());
+        let first_unreported_diff = counter
+            .first_unreported()
+            .duration_since(restored_with_unreported.first_unreported());
 
         assert!(first_diff < Duration::from_millis(1));
         assert!(last_diff < Duration::from_millis(1));
+        assert!(last_reported_diff < Duration::from_millis(1));
+        assert!(first_unreported_diff < Duration::from_millis(1));
     }
 }

--- a/src/infrastructure/redis_storage.rs
+++ b/src/infrastructure/redis_storage.rs
@@ -79,6 +79,36 @@ use tokio::sync::RwLock;
 struct SerializableEventState {
     policy: crate::domain::policy::Policy,
     suppressed_count: usize,
+    reported_count: usize,
+    first_suppressed_secs: u64,
+    first_suppressed_nanos: u32,
+    last_suppressed_secs: u64,
+    last_suppressed_nanos: u32,
+    last_reported_secs: u64,
+    last_reported_nanos: u32,
+    first_unreported_secs: u64,
+    first_unreported_nanos: u32,
+}
+
+/// Serialized form used before first-unreported progress was persisted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ReportedSerializableEventState {
+    policy: crate::domain::policy::Policy,
+    suppressed_count: usize,
+    reported_count: usize,
+    first_suppressed_secs: u64,
+    first_suppressed_nanos: u32,
+    last_suppressed_secs: u64,
+    last_suppressed_nanos: u32,
+    last_reported_secs: u64,
+    last_reported_nanos: u32,
+}
+
+/// Legacy serialized form used before active-emission progress was persisted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LegacySerializableEventState {
+    policy: crate::domain::policy::Policy,
+    suppressed_count: usize,
     first_suppressed_secs: u64,
     first_suppressed_nanos: u32,
     last_suppressed_secs: u64,
@@ -93,18 +123,80 @@ impl SerializableEventState {
         // Convert Instant to Duration since base_instant for serialization
         let first_duration = counter.first_suppressed.duration_since(base_instant);
         let last_duration = counter.last_suppressed.duration_since(base_instant);
+        let last_reported_duration = counter.last_reported.duration_since(base_instant);
+        let first_unreported_duration = counter.first_unreported.duration_since(base_instant);
 
         Self {
             policy: state.policy.clone(),
             suppressed_count: counter.suppressed_count,
+            reported_count: counter.reported_count,
             first_suppressed_secs: first_duration.as_secs(),
             first_suppressed_nanos: first_duration.subsec_nanos(),
             last_suppressed_secs: last_duration.as_secs(),
             last_suppressed_nanos: last_duration.subsec_nanos(),
+            last_reported_secs: last_reported_duration.as_secs(),
+            last_reported_nanos: last_reported_duration.subsec_nanos(),
+            first_unreported_secs: first_unreported_duration.as_secs(),
+            first_unreported_nanos: first_unreported_duration.subsec_nanos(),
         }
     }
 
     /// Convert to runtime EventState.
+    fn to_event_state(&self, base_instant: Instant) -> EventState {
+        let first_suppressed =
+            base_instant + Duration::new(self.first_suppressed_secs, self.first_suppressed_nanos);
+        let last_suppressed =
+            base_instant + Duration::new(self.last_suppressed_secs, self.last_suppressed_nanos);
+        let last_reported =
+            base_instant + Duration::new(self.last_reported_secs, self.last_reported_nanos);
+        let first_unreported =
+            base_instant + Duration::new(self.first_unreported_secs, self.first_unreported_nanos);
+
+        EventState::from_snapshot_with_reported_and_first_unreported(
+            self.policy.clone(),
+            self.suppressed_count,
+            self.reported_count,
+            first_suppressed,
+            last_suppressed,
+            last_reported,
+            first_unreported,
+        )
+    }
+}
+
+fn serialize_event_state(
+    state: &EventState,
+    base_instant: Instant,
+) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
+    bincode::serialize(&SerializableEventState::from_event_state(
+        state,
+        base_instant,
+    ))
+}
+
+impl ReportedSerializableEventState {
+    /// Convert serialized state without a first-unreported cursor to runtime EventState.
+    fn to_event_state(&self, base_instant: Instant) -> EventState {
+        let first_suppressed =
+            base_instant + Duration::new(self.first_suppressed_secs, self.first_suppressed_nanos);
+        let last_suppressed =
+            base_instant + Duration::new(self.last_suppressed_secs, self.last_suppressed_nanos);
+        let last_reported =
+            base_instant + Duration::new(self.last_reported_secs, self.last_reported_nanos);
+
+        EventState::from_snapshot_with_reported(
+            self.policy.clone(),
+            self.suppressed_count,
+            self.reported_count,
+            first_suppressed,
+            last_suppressed,
+            last_reported,
+        )
+    }
+}
+
+impl LegacySerializableEventState {
+    /// Convert legacy serialized state to runtime EventState.
     fn to_event_state(&self, base_instant: Instant) -> EventState {
         let first_suppressed =
             base_instant + Duration::new(self.first_suppressed_secs, self.first_suppressed_nanos);
@@ -198,13 +290,30 @@ impl RedisStorage {
 
     /// Get a value from Redis, deserializing it.
     async fn get(&self, signature: &EventSignature) -> Result<Option<EventState>, RedisError> {
-        let key = self.key(signature);
         let mut conn = self.connection.write().await;
 
+        self.get_with_conn(signature, &mut conn).await
+    }
+
+    /// Get a value using an already-held Redis connection.
+    async fn get_with_conn(
+        &self,
+        signature: &EventSignature,
+        conn: &mut ConnectionManager,
+    ) -> Result<Option<EventState>, RedisError> {
+        let key = self.key(signature);
         let bytes: Option<Vec<u8>> = conn.get(&key).await?;
 
         if let Some(bytes) = bytes {
             if let Ok(serializable) = bincode::deserialize::<SerializableEventState>(&bytes) {
+                Ok(Some(serializable.to_event_state(self.base_instant)))
+            } else if let Ok(serializable) =
+                bincode::deserialize::<ReportedSerializableEventState>(&bytes)
+            {
+                Ok(Some(serializable.to_event_state(self.base_instant)))
+            } else if let Ok(serializable) =
+                bincode::deserialize::<LegacySerializableEventState>(&bytes)
+            {
                 Ok(Some(serializable.to_event_state(self.base_instant)))
             } else {
                 // Corrupted data, delete it
@@ -218,13 +327,21 @@ impl RedisStorage {
 
     /// Set a value in Redis, serializing it with TTL.
     async fn set(&self, signature: &EventSignature, state: &EventState) -> Result<(), RedisError> {
+        let mut conn = self.connection.write().await;
+
+        self.set_with_conn(signature, state, &mut conn).await
+    }
+
+    /// Set a value using an already-held Redis connection.
+    async fn set_with_conn(
+        &self,
+        signature: &EventSignature,
+        state: &EventState,
+        conn: &mut ConnectionManager,
+    ) -> Result<(), RedisError> {
         let key = self.key(signature);
-        let serializable = SerializableEventState::from_event_state(state, self.base_instant);
-
-        if let Ok(bytes) = bincode::serialize(&serializable) {
-            let mut conn = self.connection.write().await;
+        if let Ok(bytes) = serialize_event_state(state, self.base_instant) {
             let ttl_secs = self.config.ttl.as_secs();
-
             conn.set_ex::<_, _, ()>(&key, bytes, ttl_secs).await?;
         }
 
@@ -411,7 +528,8 @@ impl Storage<EventSignature, EventState> for RedisStorage {
                     if let Some(sig_str) = key.strip_prefix(&self.config.key_prefix) {
                         if let Ok(sig_hash) = sig_str.parse::<u64>() {
                             let signature = EventSignature::from_hash(sig_hash);
-                            if let Ok(Some(state)) = self.get(&signature).await {
+                            if let Ok(Some(state)) = self.get_with_conn(&signature, &mut conn).await
+                            {
                                 f(&signature, &state);
                             }
                         }
@@ -459,7 +577,12 @@ impl Storage<EventSignature, EventState> for RedisStorage {
                     if let Some(sig_str) = key.strip_prefix(&self.config.key_prefix) {
                         if let Ok(sig_hash) = sig_str.parse::<u64>() {
                             let signature = EventSignature::from_hash(sig_hash);
-                            if let Ok(Some(mut state)) = self.get(&signature).await {
+                            if let Ok(Some(mut state)) =
+                                self.get_with_conn(&signature, &mut conn).await
+                            {
+                                let original_bytes =
+                                    serialize_event_state(&state, self.base_instant).ok();
+
                                 if !f(&signature, &mut state) {
                                     // Delete key - predicate returned false
                                     if let Err(e) = conn.del::<_, ()>(&key).await {
@@ -469,9 +592,13 @@ impl Storage<EventSignature, EventState> for RedisStorage {
                                             "Failed to delete key from Redis during retain"
                                         );
                                     }
-                                } else {
-                                    // Update key - predicate returned true
-                                    if let Err(e) = self.set(&signature, &state).await {
+                                } else if original_bytes
+                                    != serialize_event_state(&state, self.base_instant).ok()
+                                {
+                                    // Update key only when predicate mutated state.
+                                    if let Err(e) =
+                                        self.set_with_conn(&signature, &state, &mut conn).await
+                                    {
                                         tracing::warn!(
                                             error = %e,
                                             signature = %signature.as_hash(),

--- a/tests/redis_storage.rs
+++ b/tests/redis_storage.rs
@@ -5,8 +5,10 @@
 
 #![cfg(feature = "redis-storage")]
 
+use redis::AsyncCommands;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tracing_throttle::application::emitter::{EmitterConfig, SummaryEmitter};
 use tracing_throttle::application::ports::Storage;
 use tracing_throttle::application::registry::{EventState, SuppressionRegistry};
 use tracing_throttle::domain::signature::EventSignature;
@@ -15,7 +17,14 @@ use tracing_throttle::{Policy, RedisStorage, RedisStorageConfig};
 
 /// Check if Redis is available before running tests
 async fn redis_available() -> bool {
-    RedisStorage::connect("redis://127.0.0.1/").await.is_ok()
+    matches!(
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            RedisStorage::connect("redis://127.0.0.1/")
+        )
+        .await,
+        Ok(Ok(_))
+    )
 }
 
 /// Create a test storage with unique prefix
@@ -82,6 +91,98 @@ async fn test_redis_basic_set_get() {
         |state| {
             assert_eq!(state.counter.count(), 1);
         },
+    );
+
+    storage.clear();
+}
+
+#[tokio::test]
+#[ignore] // Requires Redis
+async fn test_redis_persists_reported_suppressions() {
+    if !redis_available().await {
+        eprintln!("Skipping test: Redis not available");
+        return;
+    }
+
+    let storage = create_test_storage("reported_suppressions").await;
+    storage.clear();
+
+    let clock = Arc::new(SystemClock::new());
+    let policy = Policy::count_based(100).unwrap();
+    let registry = SuppressionRegistry::new(storage.clone(), clock, policy);
+    let sig = EventSignature::simple("INFO", "Redis reported test");
+
+    registry.with_event_state(sig, |state, now| {
+        for _ in 0..3 {
+            state.counter.record_suppression(now);
+        }
+    });
+
+    let emitter = SummaryEmitter::new(registry.clone(), EmitterConfig::default());
+    let summaries = emitter.collect_summaries();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].count, 3);
+
+    storage.with_entry_mut(
+        sig,
+        || panic!("Entry should exist"),
+        |state| {
+            assert_eq!(state.counter.count(), 3);
+            assert_eq!(state.counter.reported_count(), 3);
+            assert_eq!(state.counter.unreported_count(), 0);
+        },
+    );
+
+    let summaries = emitter.collect_summaries();
+    assert!(
+        summaries.is_empty(),
+        "reported suppressions should not be re-emitted after Redis round-trip"
+    );
+
+    storage.clear();
+}
+
+#[tokio::test]
+#[ignore] // Requires Redis
+async fn test_redis_retain_does_not_refresh_unchanged_ttl() {
+    if !redis_available().await {
+        eprintln!("Skipping test: Redis not available");
+        return;
+    }
+
+    let key_prefix = "test:retain_ttl:".to_string();
+    let storage = RedisStorage::connect_with_config(
+        "redis://127.0.0.1/",
+        RedisStorageConfig {
+            key_prefix: key_prefix.clone(),
+            ttl: Duration::from_secs(5),
+        },
+    )
+    .await
+    .expect("Failed to connect to Redis");
+    storage.clear();
+
+    let clock = Arc::new(SystemClock::new());
+    let policy = Policy::count_based(100).unwrap();
+    let registry = SuppressionRegistry::new(storage.clone(), clock, policy);
+    let sig = EventSignature::simple("INFO", "Redis TTL test");
+
+    registry.with_event_state(sig, |_state, _now| {});
+
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    let mut conn = redis::aio::ConnectionManager::new(client).await.unwrap();
+    let key = format!("{}{}", key_prefix, sig);
+
+    let ttl_before: i64 = conn.ttl(&key).await.unwrap();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let emitter = SummaryEmitter::new(registry.clone(), EmitterConfig::default());
+    assert!(emitter.collect_summaries().is_empty());
+
+    let ttl_after: i64 = conn.ttl(&key).await.unwrap();
+    assert!(
+        ttl_after < ttl_before,
+        "unchanged retain should not refresh TTL: before={ttl_before}, after={ttl_after}"
     );
 
     storage.clear();

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -157,7 +157,7 @@ async fn test_explicit_shutdown_in_application() {
     tokio::time::sleep(Duration::from_millis(250)).await;
 
     let emissions_before = app.emission_count();
-    assert!(emissions_before >= 2);
+    assert_eq!(emissions_before, 1);
 
     // Explicit shutdown
     app.shutdown().await;


### PR DESCRIPTION
## Summary
- emit suppression summaries only for newly unreported suppressions
- persist reported-summary cursors in Redis so active emission does not repeat after reloads
- roll back claimed summaries when emission panics so they can be retried
- avoid refreshing Redis TTLs when active-emission scans leave state unchanged

Fixes #4

## Testing
- cargo test --quiet
- cargo test --features redis-storage --quiet
- cargo test --features redis-storage --no-default-features --quiet
- cargo clippy --all-targets --features redis-storage --quiet -- -D warnings
- git diff --check