### PR TITLE
fix: Handle recording spans without having to add as filter and layer.

### DIFF
--- a/src/infrastructure/layer.rs
+++ b/src/infrastructure/layer.rs
@@ -1013,6 +1013,8 @@ where
         id: &tracing::span::Id,
         ctx: Context<'_, Sub>,
     ) {
+        // Older versions of tracing-throttle asked you to add the TracingRateLimitLayer
+        // as both a filter and a layer, and we needed this.
         self.record_span_context(attrs, id, ctx);
     }
 }
@@ -1667,5 +1669,60 @@ mod tests {
         );
 
         layer_clone.shutdown().await.expect("shutdown failed");
+    }
+
+    #[cfg(all(feature = "async", feature = "human-readable"))]
+    #[tokio::test]
+    async fn test_filter_only_summary_includes_span_context_fields() {
+        use std::borrow::Cow;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        let summaries = Arc::new(Mutex::new(Vec::new()));
+
+        let layer = {
+            let summaries = summaries.clone();
+            TracingRateLimitLayer::builder()
+                .with_policy(Policy::count_based(1).unwrap())
+                .with_active_emission(true)
+                .with_summary_interval(Duration::from_millis(50))
+                .with_span_context_fields(vec!["stream_id".to_string()])
+                .with_summary_formatter(Arc::new(move |summary| {
+                    summaries.lock().unwrap().push(summary.clone());
+                }))
+                .build()
+                .unwrap()
+        };
+
+        let layer_clone = layer.clone();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(layer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("stream", stream_id = "a");
+            let _enter = span.enter();
+
+            for _ in 0..4 {
+                tracing::info!("foo");
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        layer_clone.shutdown().await.expect("shutdown failed");
+
+        let summaries = summaries.lock().unwrap();
+        let summary = summaries
+            .iter()
+            .find(|summary| summary.metadata.is_some())
+            .expect("expected a summary with metadata");
+
+        let metadata = summary.metadata.as_ref().unwrap();
+        assert_eq!(
+            metadata
+                .fields
+                .get(&Cow::Borrowed("stream_id"))
+                .map(Cow::as_ref),
+            Some("a")
+        );
     }
 }

--- a/src/infrastructure/layer.rs
+++ b/src/infrastructure/layer.rs
@@ -58,6 +58,8 @@ pub enum BuildError {
     EmitterConfig(crate::application::emitter::EmitterConfigError),
 }
 
+struct CachedSpanFields(BTreeMap<Cow<'static, str>, Cow<'static, str>>);
+
 impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -631,16 +633,14 @@ where
             for span_ref in span.scope() {
                 let extensions = span_ref.extensions();
 
-                if let Some(stored_fields) =
-                    extensions.get::<BTreeMap<Cow<'static, str>, Cow<'static, str>>>()
-                {
+                if let Some(stored_fields) = extensions.get::<CachedSpanFields>() {
                     for field_name in self.span_context_fields.as_ref() {
                         // Create an owned Cow since we can't guarantee 'static lifetime from the String
                         let field_key: Cow<'static, str> = Cow::Owned(field_name.clone());
                         if let std::collections::btree_map::Entry::Vacant(e) =
                             context_fields.entry(field_key.clone())
                         {
-                            if let Some(value) = stored_fields.get(&field_key) {
+                            if let Some(value) = stored_fields.0.get(&field_key) {
                                 e.insert(value.clone());
                             }
                         }
@@ -654,6 +654,29 @@ where
         }
 
         context_fields
+    }
+
+    /// Handle entering a new span.
+    fn record_span_context<Sub>(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, Sub>,
+    ) where
+        Sub: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        if self.span_context_fields.is_empty() {
+            return;
+        }
+
+        if let Some(span) = ctx.span(id) {
+            let mut visitor = FieldVisitor::new();
+            attrs.record(&mut visitor);
+            let fields = visitor.into_fields();
+
+            let mut extensions = span.extensions_mut();
+            extensions.replace(CachedSpanFields(fields));
+        }
     }
 
     /// Extract event fields from an event.
@@ -968,6 +991,15 @@ where
             self.should_allow(signature)
         }
     }
+
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, Sub>,
+    ) {
+        self.record_span_context(attrs, id, ctx);
+    }
 }
 
 impl<S, Sub> Layer<Sub> for TracingRateLimitLayer<S>
@@ -981,18 +1013,7 @@ where
         id: &tracing::span::Id,
         ctx: Context<'_, Sub>,
     ) {
-        if self.span_context_fields.is_empty() {
-            return;
-        }
-
-        let mut visitor = FieldVisitor::new();
-        attrs.record(&mut visitor);
-        let fields = visitor.into_fields();
-
-        if let Some(span) = ctx.span(id) {
-            let mut extensions = span.extensions_mut();
-            extensions.insert(fields);
-        }
+        self.record_span_context(attrs, id, ctx);
     }
 }
 

--- a/src/infrastructure/layer.rs
+++ b/src/infrastructure/layer.rs
@@ -1007,16 +1007,6 @@ where
     S: Storage<EventSignature, EventState> + Clone + 'static,
     Sub: Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
-    fn on_new_span(
-        &self,
-        attrs: &tracing::span::Attributes<'_>,
-        id: &tracing::span::Id,
-        ctx: Context<'_, Sub>,
-    ) {
-        // Older versions of tracing-throttle asked you to add the TracingRateLimitLayer
-        // as both a filter and a layer, and we needed this.
-        self.record_span_context(attrs, id, ctx);
-    }
 }
 
 #[cfg(test)]

--- a/src/infrastructure/visitor.rs
+++ b/src/infrastructure/visitor.rs
@@ -5,18 +5,14 @@
 //!
 //! ## Architecture
 //!
-//! The span context rate limiting feature uses a dual-layer pattern:
+//! The span context rate limiting feature records span fields in extensions
+//! and uses those cached fields when computing event signatures.  These get called
+//! from `TracingRateLimitLayer`'s `Filter` implementation:
 //!
-//! 1. **Field Storage Layer**: The first `TracingRateLimitLayer` instance implements
-//!    the `Layer` trait and its `on_new_span` method stores span fields in extensions
-//!    using this `FieldVisitor`.
+//! 1. `on_new_span()` method stores span fields in extensions using this `FieldVisitor`.
 //!
-//! 2. **Filter Layer**: The second `TracingRateLimitLayer` instance (a clone of the first)
-//!    is used as a `Filter` on the capture layer. It extracts fields from span extensions
+//! 2. `event_enabled()` extracts the stored fields, and fields from each event,
 //!    and uses them in signature computation.
-//!
-//! Both layers share the same underlying `RateLimiter` (via `Arc`), so rate limiting
-//! state is consistent across both instances.
 //!
 //! ## Usage
 //!
@@ -27,11 +23,8 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! // Dual layer setup
-//! let rate_limit_filter = rate_limit.clone();
 //! let subscriber = tracing_subscriber::registry()
-//!     .with(rate_limit)  // Stores span fields via on_new_span
-//!     .with(capture.with_filter(rate_limit_filter));  // Filters using those fields
+//!     .with(capture.with_filter(rate_limit_filter));
 //! ```
 
 use std::borrow::Cow;

--- a/src/infrastructure/visitor.rs
+++ b/src/infrastructure/visitor.rs
@@ -24,7 +24,7 @@
 //!     .unwrap();
 //!
 //! let subscriber = tracing_subscriber::registry()
-//!     .with(capture.with_filter(rate_limit_filter));
+//!     .with(capture.with_filter(rate_limit));
 //! ```
 
 use std::borrow::Cow;

--- a/tests/event_fields.rs
+++ b/tests/event_fields.rs
@@ -214,10 +214,7 @@ fn test_combined_span_context_and_event_fields() {
 
     let capture = MockCaptureLayer::new();
 
-    let rate_limit_filter = rate_limit.clone();
-    let subscriber = tracing_subscriber::registry()
-        .with(rate_limit)
-        .with(capture.clone().with_filter(rate_limit_filter));
+    let subscriber = tracing_subscriber::registry().with(capture.clone().with_filter(rate_limit));
 
     tracing::subscriber::with_default(subscriber, || {
         // Alice's AUTH_FAILED errors
@@ -267,10 +264,8 @@ fn test_excluded_fields_with_span_context() {
 
     let capture = MockCaptureLayer::new();
 
-    let rate_limit_filter = rate_limit.clone();
-    let subscriber = tracing_subscriber::registry()
-        .with(rate_limit)
-        .with(capture.clone().with_filter(rate_limit_filter));
+    let subscriber =
+        tracing_subscriber::registry().with(capture.clone().with_filter(rate_limit));
 
     tracing::subscriber::with_default(subscriber, || {
         let span = tracing::info_span!("request", user_id = "alice");

--- a/tests/event_fields.rs
+++ b/tests/event_fields.rs
@@ -264,8 +264,7 @@ fn test_excluded_fields_with_span_context() {
 
     let capture = MockCaptureLayer::new();
 
-    let subscriber =
-        tracing_subscriber::registry().with(capture.clone().with_filter(rate_limit));
+    let subscriber = tracing_subscriber::registry().with(capture.clone().with_filter(rate_limit));
 
     tracing::subscriber::with_default(subscriber, || {
         let span = tracing::info_span!("request", user_id = "alice");


### PR DESCRIPTION
This fixes #7.

In the unit tests that were testing this, we were adding the throttle as both a filter and a layer.  This makes it so we can add it just as a filter, and it'll still record fields from the span (it'll still work if you add it as both; it's backward compatible).

This also, as [recommended by the tracing_subscriber docs](https://docs.rs/tracing-subscriber/0.3.23/tracing_subscriber/registry/struct.ExtensionsMut.html) uses a newtype for the extension type, instead of a BTreeMap.